### PR TITLE
fix for OODT-782 contributed by murick

### DIFF
--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/etc/workflow.properties
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/etc/workflow.properties
@@ -33,7 +33,7 @@ org.apache.oodt.cas.workflow.engine.unlimitedQueue=true
 org.apache.oodt.cas.workflow.engine.preConditionWaitTime=10
 
 # set this if you want the workflow manager to submit jobs through the resource mgr
-org.apache.oodt.cas.workflow.engine.resourcemgr.url=http://localhost:9300
+org.apache.oodt.cas.workflow.engine.resourcemgr.url=http://localhost:9002
 
 # if you use the resource mgr submission, you can specify how many seconds the 
 # workflow manager should wait inbetween checking to see if a job is complete


### PR DESCRIPTION
File $WORKFLOW_HOME/etc/workflow.properties contains the following line: 
org.apache.oodt.cas.workflow.engine.resourcemgr.url=http://localhost:9300
Resource manager URL needs to be replaced with its default value (http://localhost:9002)
