### PR TITLE
fix for OODT-783 contributed by Mengying (Angela) Wang

### DIFF
--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/src/main/resources/policy/action-beans.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/src/main/resources/policy/action-beans.xml
@@ -30,7 +30,7 @@ the License.
             <props>
                 <prop key="crawler.failure.dir">[FAILURE_DIR]</prop>
                 <prop key="crawler.backup.dir">[BACKUP_DIR]</prop>
-                <prop key="crawler.workflowmgr.url">[WORKFLOWMGR_URL]</prop>
+                <prop key="crawler.workflowmgr.url">[WORKFLOW_URL]</prop>
                 <prop key="crawler.filemgr.url">[FILEMGR_URL]</prop>
                 <prop key="crawler.client.transferer">org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory</prop>
                 <prop key="crawler.met.file.ext">met</prop>


### PR DESCRIPTION
The action-beans.xml file in the crawler refers to a property WORKFLOWMGR_URL 
that is not consistent with OODT RADIX deployment, where this property 
is referred to as an environment variable named WORKFLOW_URL.
