### PR TITLE
Change shebang to bash for proper color output

### DIFF
--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/distribution/src/main/resources/bin/oodt
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/distribution/src/main/resources/bin/oodt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
When running `./oodt start` using the `#!/bin/sh` shebang I get,
![screen shot using sh](https://cloud.githubusercontent.com/assets/2089880/4964340/b2651816-670d-11e4-97e5-43fc1ced0bde.png)
When running it with the `#!/usr/bin/env bash` shebang I get,
![screen shot using bash](https://cloud.githubusercontent.com/assets/2089880/4964342/cc2582f4-670d-11e4-8615-8399bb9b5862.png)
