### PR TITLE
fix for Queue order assertion failure for cas-resource

### DIFF
--- a/resource/src/main/java/org/apache/oodt/cas/resource/scheduler/QueueManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/scheduler/QueueManager.java
@@ -21,7 +21,7 @@ package org.apache.oodt.cas.resource.scheduler;
 import org.apache.oodt.cas.resource.structs.exceptions.QueueManagerException;
 
 //JDK imports
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +41,7 @@ public class QueueManager {
 	protected Map<String, LinkedHashSet<String>> queueToNodesMapping;
 	
 	public QueueManager() {
-		this.queueToNodesMapping = new HashMap<String, LinkedHashSet<String>>();
+		this.queueToNodesMapping = new LinkedHashMap<String, LinkedHashSet<String>>();
 	}
 	
 	public synchronized boolean containsQueue(String queueName) {


### PR DESCRIPTION
Fixes issue OODT-830.

Queue Assertion failure of XmlQueueRepository under CAS Resource Manager

Intuition: Tracing the code led to line 44 under QueueManager where queueToNodesMapping was built on top of a HashMap. Using this under JDK8 probably causes the hashing function to insert items into queue differently than expected. Changing this to a LinkedHashMap fixed the issue
