### PR TITLE
OODT-823 Fix javadoc maven goal error

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -318,6 +318,9 @@ the License.
                         <goals>
                             <goal>javadoc</goal>
                         </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/resource/src/main/java/org/apache/oodt/cas/resource/scheduler/QueueManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/scheduler/QueueManager.java
@@ -21,7 +21,7 @@ package org.apache.oodt.cas.resource.scheduler;
 import org.apache.oodt.cas.resource.structs.exceptions.QueueManagerException;
 
 //JDK imports
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +41,7 @@ public class QueueManager {
 	protected Map<String, LinkedHashSet<String>> queueToNodesMapping;
 	
 	public QueueManager() {
-		this.queueToNodesMapping = new HashMap<String, LinkedHashSet<String>>();
+		this.queueToNodesMapping = new LinkedHashMap<String, LinkedHashSet<String>>();
 	}
 	
 	public synchronized boolean containsQueue(String queueName) {


### PR DESCRIPTION
This fix relaxes the doclint setting which is set by default for jdk8. 
This ensures that errors in javadoc syntax doesn't halt the build process. 
This can be viewed as a temporary fix. Primary goal should be to rewrite javadoc to conform to the doclint specification