### PR TITLE
Added RegEx Exclude Comparator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@ Apache OODT Change Log
 ======================
 Release 0.11 - Current Development
 
+* OODT-885 RegEx Precondition Comparator for DRAT --exclude feature
+
 * OODT-874 Corrected workflow/bin/wmgr and resource/bin/resmgr to make sure
   they both delete the cas.xxxx.pid file when stopped using the 'stop'
   command. (mallder)

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/preconditions/RegExExcludeComparator.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/preconditions/RegExExcludeComparator.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.oodt.cas.metadata.preconditions;
+
+//JDK imports
+import java.io.File;
+import java.util.regex.Pattern;
+
+//OODT imports
+import org.apache.oodt.cas.metadata.exceptions.PreconditionComparatorException;
+import org.apache.oodt.cas.metadata.preconditions.PreConditionComparator;
+
+/**
+ * 
+ * A {@link PreConditionComparator} that checks a file's absolute path and then
+ * skips if it matches with the Regular Expression provided.
+ * 
+ * @author karanjeets
+ * @version 1.0
+ * 
+ */
+public class RegExExcludeComparator extends PreConditionComparator<String> {
+	
+	protected int performCheck(File file, String compareItem)
+			throws PreconditionComparatorException {
+		if (compareItem != null
+				&& !compareItem.trim().equals("")
+				&& Pattern.matches(compareItem.toLowerCase(), file
+						.getAbsolutePath().toLowerCase()))
+			return 0;
+		return 1;
+  }
+
+}


### PR DESCRIPTION
This Comparator takes Regular Expression as input and compare it with the absolute path of data file. Returns 0 if match found, else 1.