### PR TITLE
Fix a useless error message with something more useful

### DIFF
--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
@@ -18,30 +18,16 @@
 package org.apache.oodt.cas.filemgr.system;
 
 //APACHE imports
-import org.apache.xmlrpc.WebServer;
+import com.google.common.collect.Lists;
 
-//OODT imports
-import org.apache.oodt.cas.metadata.Metadata;
-import org.apache.oodt.cas.metadata.exceptions.MetExtractionException;
-import org.apache.oodt.commons.date.DateUtils;
 import org.apache.oodt.cas.filemgr.catalog.Catalog;
+import org.apache.oodt.cas.filemgr.datatransfer.DataTransfer;
+import org.apache.oodt.cas.filemgr.datatransfer.TransferStatusTracker;
 import org.apache.oodt.cas.filemgr.metadata.ProductMetKeys;
 import org.apache.oodt.cas.filemgr.metadata.extractors.FilemgrMetExtractor;
 import org.apache.oodt.cas.filemgr.repository.RepositoryManager;
-import org.apache.oodt.cas.filemgr.structs.Element;
-import org.apache.oodt.cas.filemgr.structs.ExtractorSpec;
-import org.apache.oodt.cas.filemgr.structs.FileTransferStatus;
-import org.apache.oodt.cas.filemgr.structs.ProductPage;
-import org.apache.oodt.cas.filemgr.structs.ProductType;
-import org.apache.oodt.cas.filemgr.structs.Product;
-import org.apache.oodt.cas.filemgr.structs.Query;
-import org.apache.oodt.cas.filemgr.structs.Reference;
-import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.QueryFormulationException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.RepositoryManagerException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.DataTransferException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.ValidationLayerException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.VersioningException;
+import org.apache.oodt.cas.filemgr.structs.*;
+import org.apache.oodt.cas.filemgr.structs.exceptions.*;
 import org.apache.oodt.cas.filemgr.structs.query.ComplexQuery;
 import org.apache.oodt.cas.filemgr.structs.query.QueryFilter;
 import org.apache.oodt.cas.filemgr.structs.query.QueryResult;
@@ -49,35 +35,25 @@ import org.apache.oodt.cas.filemgr.structs.query.QueryResultComparator;
 import org.apache.oodt.cas.filemgr.structs.query.filter.ObjectTimeEvent;
 import org.apache.oodt.cas.filemgr.structs.query.filter.TimeEvent;
 import org.apache.oodt.cas.filemgr.structs.type.TypeHandler;
-import org.apache.oodt.cas.filemgr.datatransfer.DataTransfer;
 import org.apache.oodt.cas.filemgr.util.GenericFileManagerObjectFactory;
 import org.apache.oodt.cas.filemgr.util.XmlRpcStructFactory;
 import org.apache.oodt.cas.filemgr.versioning.Versioner;
 import org.apache.oodt.cas.filemgr.versioning.VersioningUtils;
-import org.apache.oodt.cas.filemgr.datatransfer.TransferStatusTracker;
+import org.apache.oodt.cas.metadata.Metadata;
+import org.apache.oodt.cas.metadata.exceptions.MetExtractionException;
+import org.apache.oodt.commons.date.DateUtils;
+import org.apache.xmlrpc.WebServer;
 
-import com.google.common.collect.Lists;
-
-
-
-
-//JDK imports
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.Arrays;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Vector;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.FileNotFoundException;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+//OODT imports
+//JDK imports
 
 /**
  * @author mattmann
@@ -1086,6 +1062,11 @@ public class XmlRpcFileManager {
 
     private Metadata runExtractors(Product product, Metadata metadata) {
         // make sure that the product type definition is present
+        if(product.getProductType() == null){
+          LOG.log(Level.SEVERE, "Failed to run extractor for: "+product.getProductId()+":"+product
+              .getProductName()+" product type cannot be null.");
+          return null;
+        }
         try {
             product.setProductType(repositoryManager.getProductTypeById(product
                     .getProductType().getProductTypeId()));

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.oodt.cas.filemgr.system;
 
-//APACHE imports
 import com.google.common.collect.Lists;
 
 import org.apache.oodt.cas.filemgr.catalog.Catalog;
@@ -26,8 +25,20 @@ import org.apache.oodt.cas.filemgr.datatransfer.TransferStatusTracker;
 import org.apache.oodt.cas.filemgr.metadata.ProductMetKeys;
 import org.apache.oodt.cas.filemgr.metadata.extractors.FilemgrMetExtractor;
 import org.apache.oodt.cas.filemgr.repository.RepositoryManager;
-import org.apache.oodt.cas.filemgr.structs.*;
-import org.apache.oodt.cas.filemgr.structs.exceptions.*;
+import org.apache.oodt.cas.filemgr.structs.Element;
+import org.apache.oodt.cas.filemgr.structs.ExtractorSpec;
+import org.apache.oodt.cas.filemgr.structs.FileTransferStatus;
+import org.apache.oodt.cas.filemgr.structs.Product;
+import org.apache.oodt.cas.filemgr.structs.ProductPage;
+import org.apache.oodt.cas.filemgr.structs.ProductType;
+import org.apache.oodt.cas.filemgr.structs.Query;
+import org.apache.oodt.cas.filemgr.structs.Reference;
+import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.DataTransferException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.QueryFormulationException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.RepositoryManagerException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.ValidationLayerException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.VersioningException;
 import org.apache.oodt.cas.filemgr.structs.query.ComplexQuery;
 import org.apache.oodt.cas.filemgr.structs.query.QueryFilter;
 import org.apache.oodt.cas.filemgr.structs.query.QueryResult;
@@ -44,16 +55,23 @@ import org.apache.oodt.cas.metadata.exceptions.MetExtractionException;
 import org.apache.oodt.commons.date.DateUtils;
 import org.apache.xmlrpc.WebServer;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-//OODT imports
-//JDK imports
 
 /**
  * @author mattmann
@@ -683,7 +701,7 @@ public class XmlRpcFileManager {
     public String ingestProduct(Hashtable<String, Object> productHash,
       Hashtable<String, String> metadata, boolean clientTransfer)
       throws VersioningException, RepositoryManagerException,
-      DataTransferException, CatalogException {
+        DataTransferException, CatalogException {
 
     Product p = XmlRpcStructFactory.getProductFromXmlRpc(productHash);
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
@@ -1060,12 +1060,13 @@ public class XmlRpcFileManager {
         return metadata;
     }
 
-    private Metadata runExtractors(Product product, Metadata metadata) {
+    private Metadata runExtractors(Product product, Metadata metadata) throws CatalogException {
         // make sure that the product type definition is present
         if(product.getProductType() == null){
           LOG.log(Level.SEVERE, "Failed to run extractor for: "+product.getProductId()+":"+product
               .getProductName()+" product type cannot be null.");
-          return null;
+          throw new CatalogException("Failed to run extractor for: "+product.getProductId()+":"+product
+              .getProductName()+" product type cannot be null.");
         }
         try {
             product.setProductType(repositoryManager.getProductTypeById(product

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManagerClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManagerClient.java
@@ -17,22 +17,37 @@
 
 package org.apache.oodt.cas.filemgr.system;
 
-//APACHE imports
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpMethodRetryHandler;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.apache.oodt.cas.cli.CmdLineUtility;
 import org.apache.oodt.cas.filemgr.datatransfer.DataTransfer;
-import org.apache.oodt.cas.filemgr.structs.*;
-import org.apache.oodt.cas.filemgr.structs.exceptions.*;
+import org.apache.oodt.cas.filemgr.structs.Element;
+import org.apache.oodt.cas.filemgr.structs.FileTransferStatus;
+import org.apache.oodt.cas.filemgr.structs.Product;
+import org.apache.oodt.cas.filemgr.structs.ProductPage;
+import org.apache.oodt.cas.filemgr.structs.ProductType;
+import org.apache.oodt.cas.filemgr.structs.Query;
+import org.apache.oodt.cas.filemgr.structs.Reference;
+import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.ConnectionException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.DataTransferException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.RepositoryManagerException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.ValidationLayerException;
+import org.apache.oodt.cas.filemgr.structs.exceptions.VersioningException;
 import org.apache.oodt.cas.filemgr.structs.query.ComplexQuery;
 import org.apache.oodt.cas.filemgr.structs.query.QueryResult;
 import org.apache.oodt.cas.filemgr.util.GenericFileManagerObjectFactory;
 import org.apache.oodt.cas.filemgr.util.XmlRpcStructFactory;
 import org.apache.oodt.cas.filemgr.versioning.Versioner;
 import org.apache.oodt.cas.metadata.Metadata;
-import org.apache.xmlrpc.*;
+import org.apache.xmlrpc.CommonsXmlRpcTransport;
+import org.apache.xmlrpc.XmlRpcClient;
+import org.apache.xmlrpc.XmlRpcClientException;
+import org.apache.xmlrpc.XmlRpcException;
+import org.apache.xmlrpc.XmlRpcTransport;
+import org.apache.xmlrpc.XmlRpcTransportFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,8 +59,6 @@ import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-//JDK imports
-//OODT imports
 
 /**
  * @author mattmann (Chris Mattmann)
@@ -1287,7 +1300,6 @@ public class XmlRpcFileManagerClient {
           throw new Exception(e2);
         }
         catch (Exception e) {
-            //e.printStackTrace();
           LOG.log(Level.SEVERE, "Failed to ingest product [ id: " + product.getProductId() +
                                 "/ name:" +product.getProductName() + "] :" + e.getMessage() + " -- rolling back ingest");
             try {

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManagerClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManagerClient.java
@@ -18,48 +18,34 @@
 package org.apache.oodt.cas.filemgr.system;
 
 //APACHE imports
-import org.apache.xmlrpc.CommonsXmlRpcTransport;
-import org.apache.xmlrpc.XmlRpcClient;
-import org.apache.xmlrpc.XmlRpcClientException;
-import org.apache.xmlrpc.XmlRpcException;
-import org.apache.xmlrpc.XmlRpcTransport;
-import org.apache.xmlrpc.XmlRpcTransportFactory;
-//JDK imports
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpMethodRetryHandler;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.oodt.cas.cli.CmdLineUtility;
+import org.apache.oodt.cas.filemgr.datatransfer.DataTransfer;
+import org.apache.oodt.cas.filemgr.structs.*;
+import org.apache.oodt.cas.filemgr.structs.exceptions.*;
+import org.apache.oodt.cas.filemgr.structs.query.ComplexQuery;
+import org.apache.oodt.cas.filemgr.structs.query.QueryResult;
+import org.apache.oodt.cas.filemgr.util.GenericFileManagerObjectFactory;
+import org.apache.oodt.cas.filemgr.util.XmlRpcStructFactory;
+import org.apache.oodt.cas.filemgr.versioning.Versioner;
+import org.apache.oodt.cas.metadata.Metadata;
+import org.apache.xmlrpc.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.net.URL;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.File;
+
+//JDK imports
 //OODT imports
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethod;
-import org.apache.commons.httpclient.HttpMethodRetryHandler;
-import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.oodt.cas.metadata.Metadata;
-import org.apache.oodt.cas.cli.CmdLineUtility;
-import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.RepositoryManagerException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.ValidationLayerException;
-import org.apache.oodt.cas.filemgr.structs.Element;
-import org.apache.oodt.cas.filemgr.structs.FileTransferStatus;
-import org.apache.oodt.cas.filemgr.structs.ProductPage;
-import org.apache.oodt.cas.filemgr.structs.ProductType;
-import org.apache.oodt.cas.filemgr.structs.Product;
-import org.apache.oodt.cas.filemgr.structs.Query;
-import org.apache.oodt.cas.filemgr.structs.Reference;
-import org.apache.oodt.cas.filemgr.util.GenericFileManagerObjectFactory;
-import org.apache.oodt.cas.filemgr.util.XmlRpcStructFactory;
-import org.apache.oodt.cas.filemgr.versioning.Versioner;
-import org.apache.oodt.cas.filemgr.structs.exceptions.VersioningException;
-import org.apache.oodt.cas.filemgr.datatransfer.DataTransfer;
-import org.apache.oodt.cas.filemgr.structs.exceptions.DataTransferException;
-import org.apache.oodt.cas.filemgr.structs.exceptions.ConnectionException;
-import org.apache.oodt.cas.filemgr.structs.query.ComplexQuery;
-import org.apache.oodt.cas.filemgr.structs.query.QueryResult;
 
 /**
  * @author mattmann (Chris Mattmann)
@@ -1286,10 +1272,24 @@ public class XmlRpcFileManagerClient {
                         + product.getProductType().getVersioner()
                         + ": Message: " + e.getMessage());
             throw new VersioningException(e);
-        } catch (Exception e) {
-            e.printStackTrace();
-            LOG.log(Level.SEVERE, "Failed to ingest product [" + product
-                    + "] : " + e.getMessage() + " -- rolling back ingest");
+        } catch(XmlRpcException e2){
+          LOG.log(Level.SEVERE, "Failed to ingest product [ name:" +product.getProductName() + "] :" + e2.getMessage() + " -- rolling back ingest");
+          try {
+            Vector<Object> argList = new Vector<Object>();
+            Hashtable<String, Object> productHash = XmlRpcStructFactory
+                .getXmlRpcProduct(product);
+            argList.add(productHash);
+            client.execute("filemgr.removeProduct", argList);
+          } catch (Exception e1) {
+            LOG.log(Level.SEVERE, "Failed to rollback ingest of product ["
+                                  + product + "] : " + e2.getMessage());
+          }
+          throw new Exception(e2);
+        }
+        catch (Exception e) {
+            //e.printStackTrace();
+          LOG.log(Level.SEVERE, "Failed to ingest product [ id: " + product.getProductId() +
+                                "/ name:" +product.getProductName() + "] :" + e.getMessage() + " -- rolling back ingest");
             try {
                 Vector<Object> argList = new Vector<Object>();
                 Hashtable<String, Object> productHash = XmlRpcStructFactory


### PR DESCRIPTION
Currently if the ingestion fails with no product type you get the message "null" because the server throws an npe and the client gets nothing in return. I've prevented the NPE and returned some more useful information