### PR TITLE
OODT-928 Update maven-compiler-plugin from 1.6 to 1.7 in core pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -560,8 +560,8 @@ mm
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>
@@ -636,7 +636,7 @@ mm
           <docencoding>UTF-8</docencoding>
           <encoding>UTF-8</encoding>
           <aggregate>true</aggregate>
-          <source>1.5</source>
+          <source>1.7</source>
         </configuration>
       </plugin>
       <!-- Produce Source cross references -->


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/OODT-928