### PR TITLE
[OODT-963] [OODT-964] [OODT-965] Added configuration listening feature and fixed workflow manager tests

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
+            <artifactId>curator-recipes</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/config/src/main/java/org/apache/oodt/config/ConfigEventType.java
+++ b/config/src/main/java/org/apache/oodt/config/ConfigEventType.java
@@ -15,31 +15,36 @@
  * limitations under the License.
  */
 
-package org.apache.oodt.config.distributed.cli;
-
-import org.apache.oodt.cas.cli.CmdLineUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package org.apache.oodt.config;
 
 /**
- * Class with main method which gets invoked by the CLI.
- * <p>
- * Basic usage:
- * <pre>
- *     ./config-publisher -connectString localhost:2181 </> -a {publish|verify|clear}
- * </pre>
- * <p>
- * Optionally, users can give <pre>-notify</pre> option to notify the listening OODT components on the configuration
- * change.
+ * An enum class to represent distributed configuration management related events.
  *
  * @author Imesha Sudasingha
  */
-public class ConfigPublisher {
+public enum ConfigEventType {
+    PUBLISH("publish"),
+    CLEAR("clear");
 
-    private static final Logger logger = LoggerFactory.getLogger(ConfigPublisher.class);
+    private String name;
 
-    public static void main(String[] args) throws Exception {
-        CmdLineUtility cmdLineUtility = new CmdLineUtility();
-        cmdLineUtility.run(args);
+    ConfigEventType(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static ConfigEventType parse(String string) {
+        switch (string) {
+            case "publish":
+                return PUBLISH;
+            case "clear":
+                return CLEAR;
+            default:
+                return null;
+        }
     }
 }

--- a/config/src/main/java/org/apache/oodt/config/ConfigurationListener.java
+++ b/config/src/main/java/org/apache/oodt/config/ConfigurationListener.java
@@ -15,31 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.oodt.config.distributed.cli;
-
-import org.apache.oodt.cas.cli.CmdLineUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package org.apache.oodt.config;
 
 /**
- * Class with main method which gets invoked by the CLI.
- * <p>
- * Basic usage:
- * <pre>
- *     ./config-publisher -connectString localhost:2181 </> -a {publish|verify|clear}
- * </pre>
- * <p>
- * Optionally, users can give <pre>-notify</pre> option to notify the listening OODT components on the configuration
- * change.
+ * The interface which should be implemented in order to listen for configuration changes.
  *
  * @author Imesha Sudasingha
  */
-public class ConfigPublisher {
+public interface ConfigurationListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConfigPublisher.class);
-
-    public static void main(String[] args) throws Exception {
-        CmdLineUtility cmdLineUtility = new CmdLineUtility();
-        cmdLineUtility.run(args);
-    }
+    /**
+     * This method is invoked when there has been any change in configuration of the interested component
+     */
+    void configurationChanged(ConfigEventType type);
 }

--- a/config/src/main/java/org/apache/oodt/config/ConfigurationManager.java
+++ b/config/src/main/java/org/apache/oodt/config/ConfigurationManager.java
@@ -17,7 +17,9 @@
 
 package org.apache.oodt.config;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The abstract class to define functions of the configuration managers.
@@ -28,6 +30,7 @@ public abstract class ConfigurationManager {
 
     protected Component component;
     protected String project;
+    private Set<ConfigurationListener> configurationListeners = new HashSet<>(1);
 
     public ConfigurationManager(Component component) {
         this(component, Constants.DEFAULT_PROJECT);
@@ -38,6 +41,12 @@ public abstract class ConfigurationManager {
         this.project = project;
     }
 
+    /**
+     * Loads configuration required for {@link #component}. If distributed configuration management is enabled, this
+     * will download configuration from zookeeper. Else, this will load properties files specified.
+     *
+     * @throws Exception
+     */
     public abstract void loadConfiguration() throws Exception;
 
     /**
@@ -46,6 +55,20 @@ public abstract class ConfigurationManager {
      * implement this operation on their own.
      */
     public abstract void clearConfiguration();
+
+    public synchronized void addConfigurationListener(ConfigurationListener listener) {
+        configurationListeners.add(listener);
+    }
+
+    public synchronized void removeConfigurationListener(ConfigurationListener listener) {
+        configurationListeners.remove(listener);
+    }
+
+    protected synchronized void notifyConfigurationChange(ConfigEventType type) {
+        for (ConfigurationListener listener : configurationListeners) {
+            listener.configurationChanged(type);
+        }
+    }
 
     public Component getComponent() {
         return component;

--- a/config/src/main/java/org/apache/oodt/config/Constants.java
+++ b/config/src/main/java/org/apache/oodt/config/Constants.java
@@ -93,5 +93,8 @@ public class Constants {
 
         /** Where other configuration files will be stored */
         public static final String CONFIGURATION_PATH_NAME = "configuration";
+
+        /** Path to be watched for configuration changes */
+        public static final String NOTIFICATIONS_PATH = "notifications";
     }
 }

--- a/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationManager.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationManager.java
@@ -19,7 +19,10 @@ package org.apache.oodt.config.distributed;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
 import org.apache.oodt.config.Component;
+import org.apache.oodt.config.ConfigEventType;
 import org.apache.oodt.config.ConfigurationManager;
 import org.apache.oodt.config.Constants;
 import org.apache.oodt.config.Constants.Properties;
@@ -38,11 +41,14 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.oodt.config.Constants.Properties.ZK_CONNECT_STRING;
 import static org.apache.oodt.config.Constants.Properties.ZK_PROPERTIES_FILE;
+import static org.apache.oodt.config.Constants.Properties.ZK_STARTUP_TIMEOUT;
 import static org.apache.oodt.config.distributed.utils.ConfigUtils.getOODTProjectName;
 
 /**
  * Distributed configuration manager implementation. This class make use of a {@link CuratorFramework} instance to
  * connect to zookeeper.
+ * <p>
+ * This class can download configuration from zookeeper and clear configuration locally downloaded.
  *
  * @author Imesha Sudasingha.
  */
@@ -57,12 +63,42 @@ public class DistributedConfigurationManager extends ConfigurationManager {
 
     private List<String> savedFiles = new ArrayList<>();
 
+    /** {@link NodeCache} to watch for configuration change notifications */
+    private NodeCache nodeCache;
+    /** This is the listener which is going to be notified on the configuration changes happening in zookeeper */
+    private NodeCacheListener nodeCacheListener = new NodeCacheListener() {
+        @Override
+        public void nodeChanged() throws Exception {
+            byte[] data = client.getData().forPath(zNodePaths.getNotificationsZNodePath());
+            if (data == null) {
+                return;
+            }
+
+            String event = new String(data);
+            ConfigEventType type = ConfigEventType.parse(event);
+            if (type != null) {
+                logger.info("Configuration changed event of type: '{}' received", type);
+                switch (type) {
+                    case PUBLISH:
+                        loadConfiguration();
+                        break;
+                    case CLEAR:
+                        clearConfiguration();
+                        break;
+                }
+
+                notifyConfigurationChange(type);
+            }
+        }
+    };
+
     public DistributedConfigurationManager(Component component) {
         super(component, getOODTProjectName());
         this.zNodePaths = new ZNodePaths(this.project, this.component.getName());
 
-        if (System.getProperty(ZK_PROPERTIES_FILE) == null && System.getProperty(Constants.Properties.ZK_CONNECT_STRING) == null) {
-            throw new IllegalArgumentException("Zookeeper requires system properties " + ZK_PROPERTIES_FILE + " or " + ZK_CONNECT_STRING + " to be set");
+        if (System.getProperty(ZK_PROPERTIES_FILE) == null && System.getProperty(ZK_CONNECT_STRING) == null) {
+            throw new IllegalArgumentException("Zookeeper requires system properties " + ZK_PROPERTIES_FILE + " or " +
+                    ZK_CONNECT_STRING + " to be set");
         }
 
         if (System.getProperty(ZK_PROPERTIES_FILE) != null) {
@@ -73,11 +109,11 @@ public class DistributedConfigurationManager extends ConfigurationManager {
             }
         }
 
-        if (System.getProperty(Constants.Properties.ZK_CONNECT_STRING) == null) {
+        if (System.getProperty(ZK_CONNECT_STRING) == null) {
             throw new IllegalArgumentException("Zookeeper requires a proper connect string to connect to zookeeper ensemble");
         }
 
-        connectString = System.getProperty(Constants.Properties.ZK_CONNECT_STRING);
+        connectString = System.getProperty(ZK_CONNECT_STRING);
         logger.info("Using zookeeper connect string : {}", connectString);
         startZookeeper();
     }
@@ -90,7 +126,8 @@ public class DistributedConfigurationManager extends ConfigurationManager {
         client = CuratorUtils.newCuratorFrameworkClient(connectString, logger);
         client.start();
         logger.info("Curator framework start operation invoked");
-        int startupTimeOutMs = Integer.parseInt(System.getProperty(Properties.ZK_STARTUP_TIMEOUT, "30000"));
+
+        int startupTimeOutMs = Integer.parseInt(System.getProperty(ZK_STARTUP_TIMEOUT, "30000"));
         try {
             logger.info("Waiting to connect to zookeeper, startupTimeout : {}", startupTimeOutMs);
             client.blockUntilConnected(startupTimeOutMs, TimeUnit.MILLISECONDS);
@@ -103,10 +140,27 @@ public class DistributedConfigurationManager extends ConfigurationManager {
         }
 
         logger.info("CuratorFramework client started successfully");
+
+        nodeCache = new NodeCache(client, zNodePaths.getNotificationsZNodePath());
+        nodeCache.getListenable().addListener(nodeCacheListener);
+        try {
+            logger.debug("Starting NodeCache to watch for configuration changes");
+            nodeCache.start(true);
+        } catch (Exception e) {
+            logger.error("Error occurred when start listening for configuration changes", e);
+            throw new IllegalStateException("Unable to start listening for configuration changes", e);
+        }
+        logger.info("NodeCache for watching configuration changes started successfully");
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Since distributed configuration management treats properties files and configuration files in two different ways,
+     * they are loaded in different manners.
+     */
     @Override
-    public void loadConfiguration() throws Exception {
+    public synchronized void loadConfiguration() throws Exception {
         logger.debug("Loading properties for : {}", component);
         loadProperties();
         logger.info("Properties loaded for : {}", component);
@@ -170,9 +224,8 @@ public class DistributedConfigurationManager extends ConfigurationManager {
     private void saveFile(String path, byte[] data) throws IOException {
         String localFilePath = ConfigUtils.fixForComponentHome(component, path);
         File localFile = new File(localFilePath);
-        if (localFile.exists()) {
-            logger.warn("Deleting already existing file at {} before writing new content", localFilePath);
-            localFile.delete();
+        if (localFile.exists() && localFile.delete()) {
+            logger.warn("Deleted already existing file at {} before writing new content", localFilePath);
         }
 
         logger.debug("Storing configuration in file: {}", localFilePath);
@@ -181,9 +234,13 @@ public class DistributedConfigurationManager extends ConfigurationManager {
         savedFiles.add(localFilePath);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method will additionally delete all the files downloaded earlier from zookeeper.
+     */
     @Override
-    public void clearConfiguration() {
+    public synchronized void clearConfiguration() {
         for (String path : savedFiles) {
             logger.debug("Removing saved file {}", path);
             File file = new File(path);

--- a/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationManager.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationManager.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.oodt.config.Constants.Properties.ZK_CONNECT_STRING;
 import static org.apache.oodt.config.Constants.Properties.ZK_PROPERTIES_FILE;
 import static org.apache.oodt.config.Constants.Properties.ZK_STARTUP_TIMEOUT;
-import static org.apache.oodt.config.distributed.utils.ConfigUtils.getOODTProjectName;
 
 /**
  * Distributed configuration manager implementation. This class make use of a {@link CuratorFramework} instance to
@@ -93,7 +92,10 @@ public class DistributedConfigurationManager extends ConfigurationManager {
     };
 
     public DistributedConfigurationManager(Component component) {
-        super(component, getOODTProjectName());
+        super(component, ConfigUtils.getOODTProjectName());
+
+        logger.info("Found project name {} for component {}", this.project, this.component);
+
         this.zNodePaths = new ZNodePaths(this.project, this.component.getName());
 
         if (System.getProperty(ZK_PROPERTIES_FILE) == null && System.getProperty(ZK_CONNECT_STRING) == null) {

--- a/config/src/main/java/org/apache/oodt/config/distributed/ZNodePaths.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/ZNodePaths.java
@@ -17,9 +17,14 @@
 
 package org.apache.oodt.config.distributed;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.oodt.config.distributed.utils.CuratorUtils;
+import org.apache.zookeeper.CreateMode;
+
 import static org.apache.oodt.config.Constants.DEFAULT_PROJECT;
 import static org.apache.oodt.config.Constants.ZPaths.COMPONENTS_PATH_NAME;
 import static org.apache.oodt.config.Constants.ZPaths.CONFIGURATION_PATH_NAME;
+import static org.apache.oodt.config.Constants.ZPaths.NOTIFICATIONS_PATH;
 import static org.apache.oodt.config.Constants.ZPaths.PROJECTS_PATH_NAME;
 import static org.apache.oodt.config.Constants.ZPaths.PROPERTIES_PATH_NAME;
 import static org.apache.oodt.config.Constants.ZPaths.SEPARATOR;
@@ -42,6 +47,9 @@ public class ZNodePaths {
     /** ZNode path for other configuration files. /projects/${project}/components/${component}/configuration */
     private String configurationZNodePath;
     private String configurationZNodeRoot;
+
+    /** ZNode to be watched for configuration changes. /projects/${project}/components/${component}/notifications */
+    private String notificationsZNodePath;
 
     /**
      * Creates the ZNode path structure accordingly to the <pre>componentName</pre> and <pre>propertiesFileNames</pre>
@@ -70,6 +78,21 @@ public class ZNodePaths {
 
         configurationZNodePath = componentZNodeRoot + CONFIGURATION_PATH_NAME;
         configurationZNodeRoot = configurationZNodePath + SEPARATOR;
+
+        notificationsZNodePath = componentZNodeRoot + NOTIFICATIONS_PATH;
+    }
+
+    /**
+     * Creates the initial ZNode structure in zookeeper. Supposed to be called by the {@link
+     * DistributedConfigurationPublisher}.
+     *
+     * @param client {@link CuratorFramework} instance
+     * @throws Exception
+     */
+    public void createZNodes(CuratorFramework client) throws Exception {
+        CuratorUtils.createZNodeIfNotExists(client, propertiesZNodePath, CreateMode.PERSISTENT, new byte[1]);
+        CuratorUtils.createZNodeIfNotExists(client, configurationZNodePath, CreateMode.PERSISTENT, new byte[1]);
+        CuratorUtils.createZNodeIfNotExists(client, notificationsZNodePath, CreateMode.PERSISTENT, new byte[1]);
     }
 
     public String getComponentZNodePath() {
@@ -98,5 +121,9 @@ public class ZNodePaths {
 
     public String getLocalPropertiesFilePath(String zNodePath) {
         return zNodePath.substring(propertiesZNodeRoot.length());
+    }
+
+    public String getNotificationsZNodePath() {
+        return notificationsZNodePath;
     }
 }

--- a/config/src/main/java/org/apache/oodt/config/distributed/utils/ConfigUtils.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/utils/ConfigUtils.java
@@ -27,6 +27,11 @@ import org.slf4j.LoggerFactory;
 import static org.apache.oodt.config.Constants.Properties.OODT_PROJECT;
 import static org.apache.oodt.config.Constants.SEPARATOR;
 
+/**
+ * A utility class to be used for configuration related tasks.
+ *
+ * @author Imesha Sudasingha
+ */
 public class ConfigUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigUtils.class);

--- a/config/src/main/java/org/apache/oodt/config/distributed/utils/ConfigUtils.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/utils/ConfigUtils.java
@@ -75,6 +75,7 @@ public class ConfigUtils {
             project = System.getenv(Env.OODT_PROJECT);
         }
 
+        logger.debug("Project name {}", project);
         return project == null ? Constants.DEFAULT_PROJECT : project;
     }
 }

--- a/config/src/main/java/org/apache/oodt/config/distributed/utils/CuratorUtils.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/utils/CuratorUtils.java
@@ -38,6 +38,11 @@ import static org.apache.oodt.config.Constants.Properties.ZK_PROPERTIES_FILE;
 import static org.apache.oodt.config.Constants.ZPaths.NAMESPACE;
 import static org.apache.oodt.config.Constants.ZPaths.SEPARATOR;
 
+/**
+ * A set of utility methods to be used to do complex operations on zookeeper using {@link CuratorFramework}
+ *
+ * @author Imesha Sudasingha
+ */
 public class CuratorUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(CuratorUtils.class);
@@ -88,8 +93,8 @@ public class CuratorUtils {
     }
 
     /**
-     * Builds a {@link CuratorFramework} instance with given connect string. Will use the {@link CuratorUtils#logger} for
-     * logging.
+     * Builds a {@link CuratorFramework} instance with given connect string. Will use the {@link CuratorUtils#logger}
+     * for logging.
      *
      * @param connectString zookeeper connect string
      * @return CuratorFramework instance created
@@ -112,11 +117,11 @@ public class CuratorUtils {
         int maxRetryCount = Integer.parseInt(System.getProperty(Constants.Properties.ZK_CONNECTION_TIMEOUT, "3"));
 
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
-                                                          .namespace(NAMESPACE)
-                                                          .connectString(connectString)
-                                                          .retryPolicy(new ExponentialBackoffRetry(retryInitialWaitMs, maxRetryCount))
-                                                          .connectionTimeoutMs(connectionTimeoutMs)
-                                                          .sessionTimeoutMs(sessionTimeoutMs);
+                .namespace(NAMESPACE)
+                .connectString(connectString)
+                .retryPolicy(new ExponentialBackoffRetry(retryInitialWaitMs, maxRetryCount))
+                .connectionTimeoutMs(connectionTimeoutMs)
+                .sessionTimeoutMs(sessionTimeoutMs);
 
         /*
          * If authorization information is available, those will be added to the client. NOTE: These auth info are

--- a/config/src/main/java/org/apache/oodt/config/test/AbstractDistributedConfigurationTest.java
+++ b/config/src/main/java/org/apache/oodt/config/test/AbstractDistributedConfigurationTest.java
@@ -25,6 +25,13 @@ import org.junit.BeforeClass;
 
 import static org.apache.oodt.config.Constants.Properties.ZK_CONNECT_STRING;
 
+/**
+ * An abstract class to be used for distributed configuration management related tests. Any test related to any OODT
+ * component can extend this class and connect to the {@link #zookeeper} instance started by this class for further
+ * steps.
+ *
+ * @author Imesha Sudasingha
+ */
 public abstract class AbstractDistributedConfigurationTest {
 
     protected static TestingServer zookeeper;

--- a/config/src/main/resources/cmd-line-options.xml
+++ b/config/src/main/resources/cmd-line-options.xml
@@ -82,4 +82,35 @@
             </bean>
         </property>
     </bean>
+
+    <bean id="notifyConfigChange" class="org.apache.oodt.cas.cli.option.AdvancedCmdLineOption">
+        <property name="shortOption" value="n"/>
+        <property name="longOption" value="notify"/>
+        <property name="description" value="Notify the configuration managers' about the configuration change done"/>
+        <property name="hasArgs" value="false"/>
+        <property name="requirementRules">
+            <list>
+                <bean class="org.apache.oodt.cas.cli.option.require.ActionDependencyRule"
+                      p:actionName="publish" p:relation="OPTIONAL"/>
+                <bean class="org.apache.oodt.cas.cli.option.require.ActionDependencyRule"
+                      p:actionName="clear" p:relation="OPTIONAL"/>
+                <bean class="org.apache.oodt.cas.cli.option.require.ActionDependencyRule"
+                      p:actionName="verify" p:relation="OPTIONAL"/>
+            </list>
+        </property>
+        <property name="handler">
+            <bean class="org.apache.oodt.cas.cli.option.handler.ApplyToActionHandler">
+                <property name="applyToActions">
+                    <list>
+                        <bean class="org.apache.oodt.cas.cli.option.handler.ApplyToAction"
+                              p:actionName="publish" p:methodName="setNotify"/>
+                        <bean class="org.apache.oodt.cas.cli.option.handler.ApplyToAction"
+                              p:actionName="verify" p:methodName="setNotify"/>
+                        <bean class="org.apache.oodt.cas.cli.option.handler.ApplyToAction"
+                              p:actionName="clear" p:methodName="setNotify"/>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
 </beans>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -260,7 +260,7 @@ the License.
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
-        <artifactId>curator-framework</artifactId>
+        <artifactId>curator-recipes</artifactId>
         <version>3.3.0</version>
       </dependency>
       <dependency>

--- a/filemgr/src/test/resources/distributed/config/config-publisher.xml
+++ b/filemgr/src/test/resources/distributed/config/config-publisher.xml
@@ -21,7 +21,6 @@
 
     <bean id="filemgr-config-publisher" class="org.apache.oodt.config.distributed.DistributedConfigurationPublisher">
         <constructor-arg value="FILE_MANAGER"/>
-
         <constructor-arg value="primary"/>
 
         <property name="propertiesFiles">

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -27,7 +27,7 @@ the License.
   <artifactId>cas-pge</artifactId>
   <name>CAS PGE Adaptor Framework</name>
   <description>Allows data processing jobs not written in conformance with the
-        PCS PGE interface to be run within the PCS.</description>
+        PCS PGE (Production Generation Executive) interface to be run within the PCS.</description>
   <!-- All dependencies should be listed in core/pom.xml and be ordered alphabetically by package and artifact.
      Once the dependency is in the core pom, it can then be used in other modules without the version tags.
      For example, within core/pom.xml:

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -203,9 +203,8 @@ the License.
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
-          <forkMode>never</forkMode>
+          <forkMode>pertest</forkMode>
           <useSystemClassLoader>false</useSystemClassLoader>
           <systemProperties>
             <property>

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManager.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManager.java
@@ -97,8 +97,7 @@ public class AvroRpcWorkflowManager implements WorkflowManager,org.apache.oodt.c
         if(engine == null){
             throw new NullPointerException("null engine");
         }
-        engine.setWorkflowManagerUrl(safeGetUrlFromString("http://"
-                + getHostname() + ":" + this.webServerPort));
+        engine.setWorkflowManagerUrl(safeGetUrlFromString("http://" + getHostname() + ":" + this.webServerPort));
         repo = getWorkflowRepositoryFromProperty();
 
         LOG.log(Level.INFO, "Starting Netty Server");


### PR DESCRIPTION
Workflow manager tests failed in when running `mvn clean install`. The problem was with the sure fire plugin in workflow manager. `<forkMode>` was set to `never` earlier. This has caused some environment variables I was setting through surefire to affect other tests as well. Changed it to `pertest`. Tests are passing now, except `org.apache.oodt.cas.workflow.system.TestAvroRpcWorkflowManager` due to a NPE which requires to be addressed separately.

This PR also include some missing commits which adds the feature to watch for configuration changes and act accordingly for **[OODT-945]**