### PR TITLE
Fix for OODT-973

### DIFF
--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/src/main/resources/bin/filemgr
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/src/main/resources/bin/filemgr
@@ -119,8 +119,8 @@ elif [ "$1" = "stop" ]; then
     if [ -f "$FILEMGR_PID" ]; then
       kill `cat $FILEMGR_PID` >/dev/null 2>&1
       if [ $? -eq 1 ]; then
-        echo "ID file ($FILEMGR_PID) found with PID `cat $FILEMGR_PID` but no matching process was found. Removed $FILEMGR_PID, now FileManager can be started."
-        `rm $FILEMGR_PID`
+        echo "PID file ${FILEMGR_PID} found with PID `cat $FILEMGR_PID` but no matching process was found. Removed ${FILEMGR_PID}, now File Manager can be started."
+        rm ${FILEMGR_PID}
         exit 1
       fi
     else

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/resmgr
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/resmgr
@@ -125,7 +125,8 @@ elif [ "$1" = "stop" ]; then
     if [ -f "$RESMGR_PID" ]; then
       kill `cat $RESMGR_PID` >/dev/null 2>&1
       if [ $? -eq 1 ]; then
-        echo "PID file ($RESMGR_PID) found but no matching process was found. Stop aborted."
+        echo "PID file ${RESMGR_PID} found with PID `cat $RESMGR_PID` but no matching process was found. Removed ${RESMGR_PID}, now Resource Manager can be started."
+        rm ${RESMGR_PID}
         exit 1
       fi
     else

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/bin/wmgr
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/bin/wmgr
@@ -120,7 +120,8 @@ elif [ "$1" = "stop" ]; then
     if [ -f "$WORKFLOW_PID" ]; then
       kill `cat $WORKFLOW_PID` >/dev/null 2>&1
       if [ $? -eq 1 ]; then
-        echo "PID file ($WORKFLOW_PID) found but no matching process was found. Stop aborted."
+        echo "PID file ${WORKFLOW_PID} found with PID `cat $WORKFLOW_PID` but no matching process was found. Removed ${WORKFLOW_PID}, now Workflow Manager can be started."
+        rm ${WORKFLOW_PID}
         exit 1
       fi
     else


### PR DESCRIPTION
In mvn/archetypes/radix module script templates, OODT stop process does not properly delete the PID files $WORKFLOW_PID & $RESMGR_PID, even when there are no matching processes to those related PIDs. Therefore workflow manager and resource manager sometime fails to start again.