### PR TITLE
Fix lucene ingest

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -287,18 +287,18 @@ the License.
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
-        <version>6.1.0</version>
+        <version>6.6.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-queryparser</artifactId>
-        <version>6.1.0</version>
+        <version>6.6.5</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-analyzers-common</artifactId>
-        <version>6.1.0</version>
+        <version>6.6.5</version>
       </dependency>
 
       <dependency>

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -632,7 +632,7 @@ public class LuceneCatalog implements Catalog {
         return products;
     }
 
-    public Metadata getMetadata(Product product) throws CatalogException {
+    public synchronized Metadata getMetadata(Product product) throws CatalogException {
         IndexSearcher searcher = null;
         try {
             try {
@@ -717,7 +717,7 @@ public class LuceneCatalog implements Catalog {
      * 
      * @see org.apache.oodt.cas.filemgr.catalog.Catalog#getTopNProducts(int)
      */
-    public List<Product> getTopNProducts(int n) throws CatalogException {
+    public synchronized List<Product> getTopNProducts(int n) throws CatalogException {
         List<Product> products = null;
         IndexSearcher searcher = null;
 
@@ -787,7 +787,7 @@ public class LuceneCatalog implements Catalog {
      * @see org.apache.oodt.cas.filemgr.catalog.Catalog#getTopNProducts(int,
      *      org.apache.oodt.cas.filemgr.structs.ProductType)
      */
-    public List<Product> getTopNProducts(int n, ProductType type)
+    public synchronized List<Product> getTopNProducts(int n, ProductType type)
             throws CatalogException {
         int numPages = 1;
         if (n > this.pageSize) {
@@ -1052,7 +1052,7 @@ public class LuceneCatalog implements Catalog {
     private synchronized void addCompleteProductToIndex(CompleteProduct cp)
             throws CatalogException {
         IndexWriter writer = null;
-        try {
+        /*try {*/
             /*writer = new IndexWriter(indexFilePath, new StandardAnalyzer(),
                     createIndex);*/
             //writer.setCommitLockTimeout(this.commitLockTimeout * 1000);
@@ -1064,12 +1064,21 @@ public class LuceneCatalog implements Catalog {
             lmp.setMergeFactor(mergeFactor);
             config.setMergePolicy(lmp);
 
-                writer = new IndexWriter(indexDir, config);
+        try {
+            writer = new IndexWriter(indexDir, config);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
-            Document doc = toDoc(cp.getProduct(), cp.getMetadata());
+        Document doc = toDoc(cp.getProduct(), cp.getMetadata());
+        try {
             writer.addDocument(doc);
-            // TODO: determine a better way to optimize the index
-        } catch (Exception e) {
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        // TODO: determine a better way to optimize the index
+       /* } catch (Exception e) {
             LOG.log(Level.WARNING, "Unable to index product: ["
                     + cp.getProduct().getProductName() + "]: Message: "
                     + e.getMessage(), e);
@@ -1084,7 +1093,7 @@ public class LuceneCatalog implements Catalog {
             } catch (Exception e) {
                 System.out.println("failed"+e.getLocalizedMessage());
             }
-        }
+        }*/
 
     }
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -18,13 +18,15 @@
 package org.apache.oodt.cas.filemgr.catalog;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.document.*;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.*;
 import org.apache.lucene.search.*;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.Version;
 import org.apache.oodt.cas.filemgr.structs.*;
 import org.apache.oodt.cas.filemgr.structs.Query;
 import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
@@ -32,16 +34,12 @@ import org.apache.oodt.cas.filemgr.structs.exceptions.ValidationLayerException;
 import org.apache.oodt.cas.filemgr.validation.ValidationLayer;
 import org.apache.oodt.cas.metadata.Metadata;
 import org.apache.oodt.commons.pagination.PaginationUtils;
-import org.apache.poi.hssf.record.formula.functions.Text;
-import org.apache.solr.schema.FieldType;
 import org.safehaus.uuid.UUID;
 import org.safehaus.uuid.UUIDGenerator;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
@@ -131,7 +129,7 @@ public class LuceneCatalog implements Catalog {
         this.mergeFactor = mergeFactor;
 
         try {
-            indexDir = NIOFSDirectory.open(new File( indexFilePath ).toPath());
+            indexDir = FSDirectory.open(new File( indexFilePath ).toPath());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -22,7 +22,7 @@ import org.apache.lucene.document.*;
 import org.apache.lucene.index.*;
 import org.apache.lucene.search.*;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
 import org.apache.oodt.cas.filemgr.structs.*;
@@ -131,7 +131,7 @@ public class LuceneCatalog implements Catalog {
         this.mergeFactor = mergeFactor;
 
         try {
-            indexDir = FSDirectory.open(new File( indexFilePath ).toPath());
+            indexDir = NIOFSDirectory.open(new File( indexFilePath ).toPath());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -1050,12 +1050,12 @@ public class LuceneCatalog implements Catalog {
     private synchronized void addCompleteProductToIndex(CompleteProduct cp)
             throws CatalogException {
         IndexWriter writer = null;
-            IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
+        IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
 
-            config.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
-            LogMergePolicy lmp =new LogDocMergePolicy();
-            lmp.setMergeFactor(mergeFactor);
-            config.setMergePolicy(lmp);
+        config.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
+        LogMergePolicy lmp = new LogDocMergePolicy();
+        lmp.setMergeFactor(mergeFactor);
+        config.setMergePolicy(lmp);
 
         try {
             writer = new IndexWriter(indexDir, config);
@@ -1067,8 +1067,8 @@ public class LuceneCatalog implements Catalog {
         try {
             writer.addDocument(doc);
             writer.close();
-        // TODO: determine a better way to optimize the index
-       } catch (Exception e) {
+            // TODO: determine a better way to optimize the index
+        } catch (Exception e) {
             LOG.log(Level.WARNING, "Unable to index product: ["
                     + cp.getProduct().getProductName() + "]: Message: "
                     + e.getMessage(), e);
@@ -1081,7 +1081,7 @@ public class LuceneCatalog implements Catalog {
                     writer.close();
                 }
             } catch (Exception e) {
-                System.out.println("failed"+e.getLocalizedMessage());
+                System.out.println("failed" + e.getLocalizedMessage());
             }
         }
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -1050,11 +1050,6 @@ public class LuceneCatalog implements Catalog {
     private synchronized void addCompleteProductToIndex(CompleteProduct cp)
             throws CatalogException {
         IndexWriter writer = null;
-        /*try {*/
-            /*writer = new IndexWriter(indexFilePath, new StandardAnalyzer(),
-                    createIndex);*/
-            //writer.setCommitLockTimeout(this.commitLockTimeout * 1000);
-            //writer.setWriteLockTimeout(this.writeLockTimeout * 1000);
             IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
 
             config.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
@@ -1072,11 +1067,8 @@ public class LuceneCatalog implements Catalog {
         try {
             writer.addDocument(doc);
             writer.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
         // TODO: determine a better way to optimize the index
-       /* } catch (Exception e) {
+       } catch (Exception e) {
             LOG.log(Level.WARNING, "Unable to index product: ["
                     + cp.getProduct().getProductName() + "]: Message: "
                     + e.getMessage(), e);
@@ -1091,7 +1083,7 @@ public class LuceneCatalog implements Catalog {
             } catch (Exception e) {
                 System.out.println("failed"+e.getLocalizedMessage());
             }
-        }*/
+        }
 
     }
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -1361,7 +1361,7 @@ public class LuceneCatalog implements Catalog {
         return numHits;
     }
 
-    private List<Product> paginateQuery(Query query, ProductType type, int pageNum, ProductPage page)
+    private synchronized List<Product> paginateQuery(Query query, ProductType type, int pageNum, ProductPage page)
             throws CatalogException {
         List<Product> products = null;
         IndexSearcher searcher = null;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/tools/CASAnalyzer.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/tools/CASAnalyzer.java
@@ -30,7 +30,6 @@ import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.analysis.standard.StandardFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
-import org.apache.lucene.analysis.util.CharArraySet;
 
 //JDK imports
 import java.io.Reader;

--- a/pcs/opsui/pom.xml
+++ b/pcs/opsui/pom.xml
@@ -167,8 +167,8 @@ the License.
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <optimize>true</optimize>
           <debug>true</debug>
         </configuration>

--- a/webapp/components/pom.xml
+++ b/webapp/components/pom.xml
@@ -121,8 +121,8 @@ the License.
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <optimize>true</optimize>
           <debug>true</debug>
         </configuration>

--- a/webapp/fmbrowser/pom.xml
+++ b/webapp/fmbrowser/pom.xml
@@ -132,8 +132,8 @@ the License.
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <optimize>true</optimize>
           <debug>true</debug>
         </configuration>

--- a/webapp/wmonitor/pom.xml
+++ b/webapp/wmonitor/pom.xml
@@ -138,8 +138,8 @@ the License.
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <optimize>true</optimize>
           <debug>true</debug>
         </configuration>


### PR DESCRIPTION
This 

a) updates the lucene version to 6.6.5 which has some fixes to the core dumps we saw
b) sets a bunch of the catalog implementations to syncronized to prevent 2 threads working on the same method concurrently which stops is closing pointers to the lucene index
c) updates the min java version for some stuff so I could actually compile it.