### PR TITLE
OODT-990 Enable OODT to build under JDK 10.X

### DIFF
--- a/cli/src/main/java/org/apache/oodt/cas/cli/CmdLineUtility.java
+++ b/cli/src/main/java/org/apache/oodt/cas/cli/CmdLineUtility.java
@@ -31,7 +31,6 @@ import static org.apache.oodt.cas.cli.util.CmdLineUtils.isAdvancedOption;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 
 //Apache imports
 import org.apache.commons.lang.Validate;
@@ -47,7 +46,6 @@ import org.apache.oodt.cas.cli.exception.CmdLineActionExecutionException;
 import org.apache.oodt.cas.cli.exception.CmdLineActionStoreException;
 import org.apache.oodt.cas.cli.exception.CmdLineConstructionException;
 import org.apache.oodt.cas.cli.exception.CmdLineOptionStoreException;
-import org.apache.oodt.cas.cli.exception.CmdLineParserException;
 import org.apache.oodt.cas.cli.option.ActionCmdLineOption;
 import org.apache.oodt.cas.cli.option.CmdLineOption;
 import org.apache.oodt.cas.cli.option.CmdLineOptionInstance;
@@ -80,7 +78,6 @@ import com.google.common.collect.Lists;
  * @author bfoster (Brian Foster)
  */
 public class CmdLineUtility {
-   private static Logger LOG = Logger.getLogger(CmdLineUtility.class.getName());
    private boolean debugMode;
    private CmdLineParser parser;
    private CmdLineConstructor constructor;

--- a/cli/src/main/java/org/apache/oodt/cas/cli/util/CmdLineUtils.java
+++ b/cli/src/main/java/org/apache/oodt/cas/cli/util/CmdLineUtils.java
@@ -18,6 +18,7 @@ package org.apache.oodt.cas.cli.util;
 
 //JDK imports
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -1113,7 +1114,7 @@ public class CmdLineUtils {
       } else if (type.equals(Double.class) || type.equals(Double.TYPE)) {
          List<Object> doubles = new LinkedList<Object>();
          for (String value : values) {
-            doubles.add(new Double(value));
+            doubles.add(Double.valueOf(value));
          }
          return doubles;
       } else if (type.equals(String.class)) {
@@ -1125,7 +1126,12 @@ public class CmdLineUtils {
       } else {
          List<Object> objects = new LinkedList<Object>();
          for (String value : values) {
-            Object object = Class.forName(value).newInstance();
+            Object object = null;
+            try {
+              object = Class.forName(value).getConstructor().newInstance();
+            } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+              e.printStackTrace();
+            }
             if (!type.isAssignableFrom(object.getClass())) {
                throw new RuntimeException(object.getClass() + " is not a valid"
                      + " type or sub-type of " + type);

--- a/commons/src/main/java/org/apache/oodt/commons/util/MemoryLogger.java
+++ b/commons/src/main/java/org/apache/oodt/commons/util/MemoryLogger.java
@@ -52,8 +52,9 @@ public class MemoryLogger implements LogListener {
 	 *
 	 * @return A list of message strings.
 	 */
-	public List getMessages() {
-		return (List) messages.clone();
+	@SuppressWarnings("unchecked")
+	public List<Object> getMessages() {
+		return (List<Object>) messages.clone();
 	}
 
 	/** Get the maximum size of the cache.
@@ -98,7 +99,7 @@ public class MemoryLogger implements LogListener {
 	}
 
 	/** The list of messages. */
-	private LinkedList messages = new LinkedList();
+	private LinkedList<Object> messages = new LinkedList<Object>();
 
 	/** Maximum size of message cache. */
 	private int size;

--- a/commons/src/test/java/org/apache/oodt/commons/util/XMLTest.java
+++ b/commons/src/test/java/org/apache/oodt/commons/util/XMLTest.java
@@ -59,7 +59,15 @@ public class XMLTest extends TestCase {
 		String result = XML.serialize(doc);
 		crc.update(result.getBytes());
 		long value = crc.getValue();
-		assertTrue("Stringified DOM document CRC mismatch, got value = " + value, 3880488030L == value || 2435419114L == value || /* added by Chris Mattmann: pretty print fix */3688328384L == value || /* other newline treatment */ 750262163L == value || 3738296466L == value /* Apache incubator warmed up the file, so it suffered thermal expansion */ || 1102069581L == value /* lewismc and his ALv2 header. */ || 3026567548L == value /* Windows 2008 Server CRC value */);
+		assertTrue("Stringified DOM document CRC mismatch, got value = " + value, 3880488030L == value 
+			|| 2435419114L == value 
+			|| /* added by Chris Mattmann: pretty print fix */3688328384L == value 
+			|| /* other newline treatment */ 750262163L == value 
+			|| 3738296466L == value /* Apache incubator warmed up the file, so it suffered thermal expansion */ 
+			|| 1102069581L == value /* lewismc and his ALv2 header. */ 
+			|| 3026567548L == value /* Windows 2008 Server CRC value */
+			|| 2790989364L == value /* Build under version JDK 10.0.2 2018-07-17 on macOS Sierra 10.12.6 */
+			);
 	}
 
 	/** Test the {@link XML#createSAXParser} method.

--- a/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationManager.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationManager.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.oodt.config.Constants.Properties.ZK_CONNECT_STRING;
 import static org.apache.oodt.config.Constants.Properties.ZK_PROPERTIES_FILE;
 import static org.apache.oodt.config.Constants.Properties.ZK_STARTUP_TIMEOUT;
-import static org.apache.oodt.config.distributed.utils.ConfigUtils.getOODTProjectName;
 
 
 /**

--- a/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationPublisher.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/DistributedConfigurationPublisher.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -273,7 +274,7 @@ public class DistributedConfigurationPublisher {
     private String getFileContent(String file) {
         String content;
         try {
-            content = FileUtils.readFileToString(new File(file));
+            content = FileUtils.readFileToString(new File(file), Charset.defaultCharset());
         } catch (IOException e) {
             logger.error("Unable to read file : {}", file, e);
             throw new IllegalArgumentException("Unable to read content of the file : " + file);

--- a/config/src/main/java/org/apache/oodt/config/distributed/cli/CLIAction.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/cli/CLIAction.java
@@ -52,7 +52,7 @@ public class CLIAction extends CmdLineAction {
     public void execute(ActionMessagePrinter printer) throws CmdLineActionException {
         try {
             ApplicationContext applicationContext = new ClassPathXmlApplicationContext(configFile);
-            Map distributedConfigurationPublisher = applicationContext.getBeansOfType(DistributedConfigurationPublisher.class);
+            Map<?, ?> distributedConfigurationPublisher = applicationContext.getBeansOfType(DistributedConfigurationPublisher.class);
 
             for (Object bean : distributedConfigurationPublisher.values()) {
                 DistributedConfigurationPublisher publisher = (DistributedConfigurationPublisher) bean;

--- a/config/src/main/java/org/apache/oodt/config/distributed/cli/ConfigPublisher.java
+++ b/config/src/main/java/org/apache/oodt/config/distributed/cli/ConfigPublisher.java
@@ -18,8 +18,6 @@
 package org.apache.oodt.config.distributed.cli;
 
 import org.apache.oodt.cas.cli.CmdLineUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class with main method which gets invoked by the CLI.
@@ -35,8 +33,6 @@ import org.slf4j.LoggerFactory;
  * @author Imesha Sudasingha
  */
 public class ConfigPublisher {
-
-    private static final Logger logger = LoggerFactory.getLogger(ConfigPublisher.class);
 
     public static void main(String[] args) throws Exception {
         CmdLineUtility cmdLineUtility = new CmdLineUtility();

--- a/config/src/test/java/org/apache/oodt/config/distributed/DistributedConfigurationManagerTest.java
+++ b/config/src/test/java/org/apache/oodt/config/distributed/DistributedConfigurationManagerTest.java
@@ -66,7 +66,7 @@ public class DistributedConfigurationManagerTest extends AbstractDistributedConf
         });
 
         ApplicationContext applicationContext = new ClassPathXmlApplicationContext(CONFIG_PUBLISHER_XML);
-        Map distributedConfigurationPublishers = applicationContext.getBeansOfType(DistributedConfigurationPublisher.class);
+        Map<?, ?> distributedConfigurationPublishers = applicationContext.getBeansOfType(DistributedConfigurationPublisher.class);
 
         publishers = new ArrayList<>();
         configurationManagers = new HashMap<>();

--- a/config/src/test/java/org/apache/oodt/config/distributed/DistributedConfigurationPublisherTest.java
+++ b/config/src/test/java/org/apache/oodt/config/distributed/DistributedConfigurationPublisherTest.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class DistributedConfigurationPublisherTest extends AbstractDistributedCo
         });
 
         ApplicationContext applicationContext = new ClassPathXmlApplicationContext(CONFIG_PUBLISHER_XML);
-        Map distributedConfigurationPublishers = applicationContext.getBeansOfType(DistributedConfigurationPublisher.class);
+        Map<?, ?> distributedConfigurationPublishers = applicationContext.getBeansOfType(DistributedConfigurationPublisher.class);
 
         List<DistributedConfigurationPublisher> publishers = new ArrayList<>(distributedConfigurationPublishers.values().size());
         for (Object bean : distributedConfigurationPublishers.values()) {
@@ -81,7 +82,7 @@ public class DistributedConfigurationPublisherTest extends AbstractDistributedCo
                 Assert.assertNotNull(client.checkExists().forPath(zNodePath));
 
                 String storedContent = new String(client.getData().forPath(zNodePath));
-                String fileContent = FileUtils.readFileToString(new File(entry.getKey()));
+                String fileContent = FileUtils.readFileToString(new File(entry.getKey()), Charset.defaultCharset());
                 Assert.assertEquals(fileContent, storedContent);
             }
 
@@ -91,7 +92,7 @@ public class DistributedConfigurationPublisherTest extends AbstractDistributedCo
                 Assert.assertNotNull(client.checkExists().forPath(zNodePath));
 
                 String storedContent = new String(client.getData().forPath(zNodePath));
-                String fileContent = FileUtils.readFileToString(new File(entry.getKey()));
+                String fileContent = FileUtils.readFileToString(new File(entry.getKey()), Charset.defaultCharset());
                 Assert.assertEquals(fileContent, storedContent);
             }
         }

--- a/config/src/test/java/org/apache/oodt/config/distributed/TestServer.java
+++ b/config/src/test/java/org/apache/oodt/config/distributed/TestServer.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 public class TestServer {
 
     public static void main(String[] args) throws Exception {
+        @SuppressWarnings("resource")
         final TestingServer zookeeper = new TestingServer(2181);
         zookeeper.start();
         System.out.printf(zookeeper.getConnectString());

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -321,6 +321,7 @@ the License.
         <version>${jena.version}</version>
         <type>pom</type>
       </dependency>
+
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
@@ -338,19 +339,8 @@ the License.
       </dependency>
       <dependency>
          <groupId>org.apache.lucene</groupId>
-	 <artifactId>lucene-backward-codecs</artifactId>
-	 <version>6.6.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-queryparser</artifactId>
-        <version>6.1.0</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-analyzers-common</artifactId>
-        <version>6.1.0</version>
+         <artifactId>lucene-backward-codecs</artifactId>
+         <version>6.6.5</version>
       </dependency>
 
       <dependency>

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/Catalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/Catalog.java
@@ -185,7 +185,7 @@ public interface Catalog extends Pagination {
      *         specified Product.
      * @throws CatalogException
      */
-    List getProductReferences(Product product) throws CatalogException;
+    List<Reference> getProductReferences(Product product) throws CatalogException;
 
     /**
      * <p>

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalog.java
@@ -90,9 +90,11 @@ public class LuceneCatalog implements Catalog {
     private int pageSize = -1;
 
     /* write lock timeout for writing to the index */
+    @SuppressWarnings("unused")
     private long writeLockTimeout = -1L;
 
     /* commit lock timeout for writing/reading to the index */
+    @SuppressWarnings("unused")
     private long commitLockTimeout = -1L;
 
     /* lucene index merge factor */
@@ -372,6 +374,7 @@ public class LuceneCatalog implements Catalog {
         return prod.getProduct();
     }
 
+    @SuppressWarnings("unused")
     private CompleteProduct getCompleteProductById(String productId)
             throws CatalogException {
         return getCompleteProductById(productId, false);
@@ -645,7 +648,7 @@ public class LuceneCatalog implements Catalog {
             }
             searcher = new IndexSearcher(reader);
             TermQuery qry = new TermQuery(new Term("*", "*"));
-            TopDocs tdocks  = searcher.search(qry, 100);
+            searcher.search(qry, 100);
             Term productIdTerm = new Term("product_id", product.getProductId());
             org.apache.lucene.search.Query query = new TermQuery(productIdTerm);
             //TODO FIX NUMBER OF RECORDS
@@ -1097,6 +1100,7 @@ public class LuceneCatalog implements Catalog {
 
     }
 
+    @SuppressWarnings("unused")
     private CompleteProduct toCompleteProduct(Document doc) {
         return toCompleteProduct(doc, true, true);
     }
@@ -1530,6 +1534,7 @@ public class LuceneCatalog implements Catalog {
 
         private Product product = null;
 
+        @SuppressWarnings("unused")
         public CompleteProduct(Metadata met, List<Reference> refs, Product p) {
             this.metadata = met;
             this.product = p;
@@ -1580,6 +1585,7 @@ public class LuceneCatalog implements Catalog {
          * @param references
          *            The references to set.
          */
+        @SuppressWarnings("unused")
         public void setReferences(List<Reference> references) {
             this.product.setProductReferences(references);
         }

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalogFactory.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/LuceneCatalogFactory.java
@@ -20,11 +20,8 @@ package org.apache.oodt.cas.filemgr.catalog;
 //JDK imports
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.logging.Logger;
 
-//OODT imports
-import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/ScienceDataCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/ScienceDataCatalog.java
@@ -268,7 +268,6 @@ public class ScienceDataCatalog implements Catalog {
     try {
       conn = this.dataSource.getConnection();
       conn.setAutoCommit(true);
-      int count = 0;
       statement = conn.createStatement();
       ResultSet rs = statement.executeQuery(queryExists);
       while (rs.next()) {
@@ -528,7 +527,7 @@ public class ScienceDataCatalog implements Catalog {
 
   public List<Reference> getProductReferences(Product product)
       throws CatalogException {
-    return Collections.EMPTY_LIST;
+    return Collections.emptyList();
   }
 
   public List<Product> getProducts() throws CatalogException {
@@ -1054,6 +1053,7 @@ public class ScienceDataCatalog implements Catalog {
     return size;
   }
 
+  @SuppressWarnings("unused")
   private String getStartDateTime(Product product) {
     String sql = "SELECT MIN(time) as start_date_time FROM dataPoint "
         + "          WHERE granule_id IN (SELECT granule_id FROM granule "
@@ -1103,6 +1103,7 @@ public class ScienceDataCatalog implements Catalog {
 
   }
 
+  @SuppressWarnings("unused")
   private String getEndDateTime(Product product) {
     String sql = "SELECT MAX(time) as end_date_time FROM dataPoint "
         + "          WHERE granule_id IN (SELECT granule_id FROM granule "

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/solr/DefaultProductSerializer.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/solr/DefaultProductSerializer.java
@@ -23,7 +23,6 @@ import org.apache.oodt.cas.filemgr.structs.Reference;
 import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
 import org.apache.oodt.cas.metadata.Metadata;
 
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/solr/SolrCatalogFactory.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/solr/SolrCatalogFactory.java
@@ -60,7 +60,7 @@ public class SolrCatalogFactory implements CatalogFactory {
 		String productSerializerClass = System.getProperty("org.apache.oodt.cas.filemgr.catalog.solr.productSerializer");
 		if (productSerializerClass!=null) {
 			try {
-				productSerializer = (ProductSerializer)Class.forName( PathUtils.replaceEnvVariables(productSerializerClass) ).newInstance();
+				productSerializer = (ProductSerializer)Class.forName( PathUtils.replaceEnvVariables(productSerializerClass) ).getConstructor().newInstance();
 			} catch(Exception e) {
 				LOG.severe(e.getMessage());
 				System.exit(-1);
@@ -73,7 +73,7 @@ public class SolrCatalogFactory implements CatalogFactory {
 		String productIdGeneratorClass = System.getProperty("org.apache.oodt.cas.filemgr.catalog.solr.productIdGenerator");
 		if (productIdGeneratorClass!=null) {
 			try {
-				productIdGenerator = (ProductIdGenerator)Class.forName( PathUtils.replaceEnvVariables(productIdGeneratorClass) ).newInstance();
+				productIdGenerator = (ProductIdGenerator)Class.forName( PathUtils.replaceEnvVariables(productIdGeneratorClass) ).getConstructor().newInstance();
 			} catch(Exception e) {
 				LOG.severe(e.getMessage());
 				System.exit(-1);

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/solr/SolrClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/catalog/solr/SolrClient.java
@@ -16,22 +16,19 @@
  */
 package org.apache.oodt.cas.filemgr.catalog.solr;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.oodt.cas.filemgr.structs.ProductType;
 import org.apache.oodt.cas.filemgr.structs.exceptions.CatalogException;
@@ -39,12 +36,7 @@ import org.apache.solr.client.solrj.util.ClientUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
@@ -286,11 +278,7 @@ public class SolrClient {
 		// build HTTP/POST request
 		HttpPost method = new HttpPost(url);
 		HttpEntity requestEntity = null;
-		try {
-			requestEntity = new StringEntity(document, mimeType, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
-		}
+		requestEntity = new StringEntity(document, ContentType.create(mimeType));
 
 		method.setEntity(requestEntity);
 		// send HTTP/POST request, return response
@@ -311,7 +299,7 @@ public class SolrClient {
 		try {
 
 			// send request
-			HttpClient httpClient = new DefaultHttpClient();
+			HttpClient httpClient = HttpClientBuilder.create().build();
 			// OODT-719 Prevent httpclient from spawning closewait tcp connections
 			method.setHeader("Connection", "close");
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/BooleanQueryCriteria.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/BooleanQueryCriteria.java
@@ -49,8 +49,6 @@ public class BooleanQueryCriteria extends QueryCriteria {
 
     public static final int NOT = 2;
 
-    private static final long serialVersionUID = 4718948237682772671L;
-
     private int operator;
 
     private List<QueryCriteria> terms;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/FreeTextQueryCriteria.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/FreeTextQueryCriteria.java
@@ -35,8 +35,6 @@ import java.util.StringTokenizer;
  */
 public class FreeTextQueryCriteria extends QueryCriteria {
 
-    private static final long serialVersionUID = 1L;
-
     private String elementName;
 
     private List<String> values;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductPage.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductPage.java
@@ -177,7 +177,7 @@ public class ProductPage {
         blank.setPageNum(0);
         blank.setTotalPages(0);
         blank.setPageSize(0);
-        blank.setPageProducts(Collections.EMPTY_LIST);
+        blank.setPageProducts(Collections.<Product> emptyList());
         return blank;
     }
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductType.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductType.java
@@ -205,8 +205,8 @@ public class ProductType {
     public static ProductType blankProductType(){
       ProductType type = new ProductType();
       type.setDescription("blank");
-      type.setExtractors(Collections.EMPTY_LIST);
-      type.setHandlers(Collections.EMPTY_LIST);
+      type.setExtractors(Collections.<ExtractorSpec> emptyList());
+      type.setHandlers(Collections.<TypeHandler> emptyList());
       type.setName("blank");
       type.setProductRepositoryPath("");
       type.setProductTypeId("");

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/RangeQueryCriteria.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/RangeQueryCriteria.java
@@ -29,8 +29,6 @@ package org.apache.oodt.cas.filemgr.structs;
  */
 public class RangeQueryCriteria extends QueryCriteria {
 
-    private static final long serialVersionUID = 1L;
-
     private String elementName;
 
     private String startValue;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/TermQueryCriteria.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/TermQueryCriteria.java
@@ -29,8 +29,6 @@ package org.apache.oodt.cas.filemgr.structs;
  */
 public class TermQueryCriteria extends QueryCriteria {
 
-    private static final long serialVersionUID = 1L;
-
     private String elementName;
 
     private String value;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManager.java
@@ -544,6 +544,7 @@ public class XmlRpcFileManager {
     return this.getProductReferencesCore(productHash);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Map<String, Object>> getProductReferencesCore(
       Map<String, Object> productHash)
       throws CatalogException {
@@ -551,7 +552,7 @@ public class XmlRpcFileManager {
     Product product = XmlRpcStructFactory.getProductFromXmlRpc(productHash);
 
     try {
-      referenceList = catalog.getProductReferences(product);
+      referenceList = (List<Reference>) catalog.getProductReferences(product);
       return XmlRpcStructFactory.getXmlRpcReferences(referenceList);
     } catch (CatalogException e) {
       LOG.log(Level.SEVERE, e.getMessage());

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/tools/SolrIndexer.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/tools/SolrIndexer.java
@@ -20,10 +20,9 @@ package org.apache.oodt.cas.filemgr.tools;
 //JDK imports
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -583,22 +582,22 @@ public class SolrIndexer {
 		    "Optimize the Solr index"));
 		options.addOption(new Option("d", "delete", false,
 		    "Delete item before indexing"));
-		options.addOption(OptionBuilder.withArgName("Solr URL").hasArg()
-		    .withDescription("URL to the Solr instance").withLongOpt("solrUrl")
-		    .create("su"));
-		options.addOption(OptionBuilder.withArgName("Filemgr URL").hasArg()
-		    .withDescription("URL to the File Manager").withLongOpt("fmUrl")
-		    .create("fmu"));
+		options.addOption(Option.builder().argName("Solr URL").hasArg()
+		    .desc("URL to the Solr instance").longOpt("solrUrl")
+		    .build());
+		options.addOption(Option.builder().argName("Filemgr URL").hasArg()
+		    .desc("URL to the File Manager").longOpt("fmUrl")
+		    .build());
 
 		OptionGroup group = new OptionGroup();
 		Option all = new Option("a", "all", false,
 		    "Index all products from the File Manager");
-		Option product = OptionBuilder.withArgName("productId").hasArg()
-		    .withDescription("Index the product from the File Manager")
-		    .withLongOpt("product").create("p");
-		Option met = OptionBuilder.withArgName("file").hasArg().withDescription(
-		    "Index the product from a metadata file").withLongOpt("metFile")
-		    .create("mf");
+		Option product = Option.builder().argName("productId").hasArg()
+		    .desc("Index the product from the File Manager")
+		    .longOpt("product").build();
+		Option met = Option.builder().argName("file").hasArg().desc(
+		    "Index the product from a metadata file").longOpt("metFile")
+		    .build();
 		Option read = new Option("r", "read", false,
 		    "Index all products based on a list of product identifiers passed in");
 		Option types = new Option("t", "types", false,
@@ -625,7 +624,7 @@ public class SolrIndexer {
 	 */
 	public static void main(String[] args)  {
 		Options options = SolrIndexer.buildCommandLine();
-		CommandLineParser parser = new GnuParser();
+		CommandLineParser parser = new DefaultParser();
 		CommandLine line = null;
 
 		try {

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestDataSourceCatalog.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestDataSourceCatalog.java
@@ -423,7 +423,8 @@ public class TestDataSourceCatalog extends TestCase {
         }
 
         try {
-            List<Reference> productReferences = myCat.getProductReferences(testProduct);
+            @SuppressWarnings("unchecked")
+            List<Reference> productReferences = (List<Reference>) myCat.getProductReferences(testProduct);
             assertNotNull(productReferences);
             assertFalse(productReferences.isEmpty());
             assertEquals(productReferences.get(0).getMimeType().getName(), "text/plain");

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestLuceneCatalog.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestLuceneCatalog.java
@@ -31,20 +31,15 @@ import org.apache.oodt.cas.metadata.Metadata;
 
 import com.google.common.collect.Lists;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
-import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import junit.framework.TestCase;
-import org.junit.Ignore;
 
 /**
  * @author woollard
@@ -63,9 +58,6 @@ public class TestLuceneCatalog extends TestCase {
     private String tmpDirPath = null;
 
     private static final int catPageSize = 20;
-
-    private Properties initialProperties = new Properties(
-      System.getProperties());
 
     public void setUpProperties() {
 
@@ -174,7 +166,6 @@ public class TestLuceneCatalog extends TestCase {
             }
         }
 
-      //  System.setProperties(initialProperties);
     }
     
     /**
@@ -410,7 +401,7 @@ public class TestLuceneCatalog extends TestCase {
         assertNotNull(page.getPageProducts());
         assertEquals(1, page.getPageProducts().size());
         assertEquals(2, page.getTotalPages());
-        List<Product> prods = page.getPageProducts();
+        page.getPageProducts();
         assertNotNull(page.getPageProducts().get(0));
         Product retProd = page.getPageProducts().get(0);
         assertEquals("ShouldBeFirstForPage.txt", retProd.getProductName());
@@ -1026,7 +1017,7 @@ public class TestLuceneCatalog extends TestCase {
 
         // set references
         Reference ref = new Reference("file:///foo.txt", "file:///bar.txt", 100);
-        Vector references = new Vector();
+        Vector<Reference> references = new Vector<Reference>();
         references.add(ref);
         testProduct.setProductReferences(references);
 

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestOrderedDataSourceCatalog.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestOrderedDataSourceCatalog.java
@@ -86,7 +86,6 @@ public class TestOrderedDataSourceCatalog extends TestDataSourceCatalog {
       fail(e.getMessage());
     }
 
-    Product retProduct;
     try {
       Metadata retMet = myCat.getMetadata(testProduct);
       assertNotNull(retMet);

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestDumpMetadataCliAction.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestDumpMetadataCliAction.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 //Apache imports
 import org.apache.commons.io.FileUtils;
@@ -70,27 +71,28 @@ public class TestDumpMetadataCliAction extends TestCase {
       ActionMessagePrinter printer = new ActionMessagePrinter();
       cliAction.execute(printer);
       assertEquals(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-          + "<cas:metadata xmlns:cas=\"http://oodt.jpl.nasa.gov/1.0/cas\">\n"
-          + "<keyval type=\"vector\">\n"
-          + "<key>Filename</key>\n"
-          + "<val>data.dat</val>\n"
-          + "</keyval>\n"
-          + "</cas:metadata>\n",
-            printer.getPrintedMessages().get(0));
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"
+          + "<cas:metadata xmlns:cas=\"http://oodt.jpl.nasa.gov/1.0/cas\">"
+          + "<keyval type=\"vector\">"
+          + "<key>Filename</key>"
+          + "<val>data.dat</val>"
+          + "</keyval>"
+          + "</cas:metadata>",
+            printer.getPrintedMessages().get(0).replaceAll("\\s{2,}", "").replaceAll("\n","").trim());
 
       cliAction.setOutputDir(tmpFile);
       cliAction.execute(printer);
       assertTrue(new File(tmpFile, FILE_NAME + ".met").exists());
       assertEquals(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-            + "<cas:metadata xmlns:cas=\"http://oodt.jpl.nasa.gov/1.0/cas\">\n"
-            + "<keyval type=\"vector\">\n"
-            + "<key>Filename</key>\n"
-            + "<val>data.dat</val>\n"
-            + "</keyval>\n"
-            + "</cas:metadata>\n",
-            FileUtils.readFileToString(new File(tmpFile, FILE_NAME + ".met")));
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"
+            + "<cas:metadata xmlns:cas=\"http://oodt.jpl.nasa.gov/1.0/cas\">"
+            + "<keyval type=\"vector\">"
+            + "<key>Filename</key>"
+            + "<val>data.dat</val>"
+            + "</keyval>"
+            + "</cas:metadata>",
+            FileUtils.readFileToString(new File(tmpFile, FILE_NAME + ".met"), 
+                    Charset.defaultCharset()).replaceAll("\\s{2,}", "").replaceAll("\n","").trim());
    }
 
    public class MockDumpMetadataCliAction extends DumpMetadataCliAction {

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/Metadata.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/Metadata.java
@@ -406,8 +406,9 @@ public class Metadata {
   public void addMetadata(Map<String, Object> metadata, boolean replace) {
     // for back compat: the old method allowed us to give it a
     // Map<String,String> and it still worked
-	for (Map.Entry<String, Object> key : metadata.entrySet()) {
-	  List<String> vals = (key.getValue() instanceof List) ? (List<String>) key.getValue()
+    for (Map.Entry<String, Object> key : metadata.entrySet()) {
+      @SuppressWarnings("unchecked")
+      List<String> vals = (key.getValue() instanceof List) ? (List<String>) key.getValue()
         : Collections.singletonList(key.getValue().toString());
       if (replace) {
         this.replaceMetadata(key.getKey(), vals);

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/SerializableMetadata.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/SerializableMetadata.java
@@ -244,6 +244,7 @@ public class SerializableMetadata extends Metadata implements Serializable {
 
                 String elemName = XMLUtils.read(keyValElem, "key",
                         this.xmlEncoding);
+                @SuppressWarnings("unchecked")
                 List<String> elemValues = XMLUtils.readMany(keyValElem, "val",
                         this.xmlEncoding);
                 this.addMetadata(elemName, elemValues);

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteConfigReader.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteConfigReader.java
@@ -46,7 +46,7 @@ public class CopyAndRewriteConfigReader implements MetExtractorConfigReader {
             throws MetExtractorConfigReaderException {
         try {
             CopyAndRewriteConfig config = new CopyAndRewriteConfig();
-            config.load(configFile.toURL().openStream());
+            config.load(configFile.toURI().toURL().openStream());
             return config;
         } catch (Exception e) {
             throw new MetExtractorConfigReaderException("Failed to parse '"

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteExtractor.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteExtractor.java
@@ -84,7 +84,7 @@ public class CopyAndRewriteExtractor extends CmdLineMetExtractor {
       try {
           met = new SerializableMetadata(new File(PathUtils
                   .replaceEnvVariables(((CopyAndRewriteConfig) this.config)
-                          .getProperty("orig.met.file.path"))).toURL()
+                          .getProperty("orig.met.file.path"))).toURI().toURL()
                   .openStream());
       } catch (Exception e) {
           LOG.log(Level.SEVERE, e.getMessage());

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/ExternConfigReader.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/ExternConfigReader.java
@@ -86,7 +86,7 @@ public final class ExternConfigReader implements MetExtractorConfigReader,
                 NodeList argNodes = argsElem.getElementsByTagName(ARG_TAG);
 
                 if (argNodes != null && argNodes.getLength() > 0) {
-                    Vector argVector = new Vector();
+                    Vector<String> argVector = new Vector<String>();
                     for (int i = 0; i < argNodes.getLength(); i++) {
                         Element argElem = (Element) argNodes.item(i);
                         String argStr;

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/ExternMetExtractor.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/ExternMetExtractor.java
@@ -78,7 +78,7 @@ public class ExternMetExtractor extends CmdLineMetExtractor implements
         File metFile = new File(metFilePath);
 
         // get exe args
-        List commandLineList = new Vector();
+        List<String> commandLineList = new Vector<String>();
         commandLineList.add(((ExternalMetExtractorConfig) this.config)
                 .getExtractorBinPath());
         if (((ExternalMetExtractorConfig) this.config).getArgList() != null

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/FilenameTokenConfig.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/FilenameTokenConfig.java
@@ -76,6 +76,7 @@ public class FilenameTokenConfig implements MetExtractorConfig {
         TOKEN_DELIMETER_SCALAR).getValue();
   }
 
+  @SuppressWarnings("unchecked")
   public List<String> getTokenMetKeyNames() {
     return (List<String>) (List<?>) this.conf.getPgeSpecificGroups().get(
         TOKEN_LIST_GROUP).getVector(TOKEN_MET_KEYS_VECTOR).getElements();
@@ -101,6 +102,7 @@ public class FilenameTokenConfig implements MetExtractorConfig {
     return met;
   }
 
+  @SuppressWarnings("unchecked")
   public Metadata getCommonMet() {
     PGEGroup commonMetGroup = this.conf.getPgeSpecificGroups().get(
         COMMON_METADATA_GROUP);

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/util/GenericMetadataObjectFactory.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/util/GenericMetadataObjectFactory.java
@@ -21,6 +21,7 @@ package org.apache.oodt.cas.metadata.util;
 //OODT imports
 import org.apache.oodt.cas.metadata.MetExtractor;
 
+import java.lang.reflect.InvocationTargetException;
 //JDK imports
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -40,12 +41,12 @@ public final class GenericMetadataObjectFactory {
       .getLogger(GenericMetadataObjectFactory.class.getName());
 
   public static MetExtractor getMetExtractorFromClassName(String className) {
-    Class metExtractorClass;
+    Class<?> metExtractorClass;
     MetExtractor extractor;
 
     try {
       metExtractorClass = Class.forName(className);
-      extractor = (MetExtractor) metExtractorClass.newInstance();
+      extractor = (MetExtractor) metExtractorClass.getConstructor().newInstance();
       return extractor;
     } catch (ClassNotFoundException e) {
       LOG.log(Level.SEVERE, e.getMessage());
@@ -62,6 +63,14 @@ public final class GenericMetadataObjectFactory {
       LOG.log(Level.WARNING,
           "IllegalAccessException when loading met extractor class "
               + className + " Message: " + e.getMessage());
+    } catch (IllegalArgumentException e) {
+      e.printStackTrace();
+    } catch (InvocationTargetException e) {
+      e.printStackTrace();
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+    } catch (SecurityException e) {
+      e.printStackTrace();
     }
 
     return null;

--- a/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEConfigFileReader.java
+++ b/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEConfigFileReader.java
@@ -155,9 +155,9 @@ public class PGEConfigFileReader {
   private void addPGESpecificGroup(PGEConfigurationFile configFile,
       Element group) throws PGEConfigFileException {
 
-    List scalars = PGEXMLFileUtils.getScalars(group);
-    List vectors = PGEXMLFileUtils.getVectors(group);
-    List matrixs = PGEXMLFileUtils.getMatrixs(group);
+    List<?> scalars = PGEXMLFileUtils.getScalars(group);
+    List<?> vectors = PGEXMLFileUtils.getVectors(group);
+    List<?> matrixs = PGEXMLFileUtils.getMatrixs(group);
 
     PGEGroup pgeGroup = new PGEGroup(group.getAttribute("name"));
 
@@ -182,7 +182,7 @@ public class PGEConfigFileReader {
 
   private void addMonitorLevels(PGEConfigurationFile configFile, Element group) {
 
-    List scalars = PGEXMLFileUtils.getScalars(group);
+    List<?> scalars = PGEXMLFileUtils.getScalars(group);
 
     if (scalars != null && scalars.size() > 0) {
       for (Object scalar1 : scalars) {
@@ -196,7 +196,7 @@ public class PGEConfigFileReader {
   private void addMonitorGroup(PGEConfigurationFile configFile, Element group)
       throws PGEConfigFileException {
 
-    List scalars = PGEXMLFileUtils.getScalars(group);
+    List<?> scalars = PGEXMLFileUtils.getScalars(group);
 
     // the list should be not be null
     if (scalars == null) {
@@ -223,7 +223,7 @@ public class PGEConfigFileReader {
 
   private void addProductPath(PGEConfigurationFile configFile, Element group)
       throws PGEConfigFileException {
-    List scalars = PGEXMLFileUtils.getScalars(group);
+    List<?> scalars = PGEXMLFileUtils.getScalars(group);
 
     // the list should be size 1
     if (scalars == null || (scalars.size() != 1)) {
@@ -247,7 +247,7 @@ public class PGEConfigFileReader {
       throws PGEConfigFileException {
 
     // get the scalars, there should be only one
-    List scalars = PGEXMLFileUtils.getScalars(group);
+    List<?> scalars = PGEXMLFileUtils.getScalars(group);
 
     // the list should be size 1
     if (scalars == null || (scalars.size() != 1)) {
@@ -291,7 +291,7 @@ public class PGEConfigFileReader {
 
   private void addScalarFilesToGroup(Element group, PGEGroup pgeGroup) {
     // get the scalars, and add them to the group
-    List scalars = PGEXMLFileUtils.getScalars(group);
+    List<?> scalars = PGEXMLFileUtils.getScalars(group);
 
     if (scalars != null && scalars.size() > 0) {
       for (Object scalar1 : scalars) {
@@ -304,7 +304,7 @@ public class PGEConfigFileReader {
   private void addVectorFilesToGroup(Element group, PGEGroup pgeGroup)
       throws PGEConfigFileException {
     // get the vectors, and add them to the group
-    List vectors = PGEXMLFileUtils.getVectors(group);
+    List<?> vectors = PGEXMLFileUtils.getVectors(group);
 
     if (vectors != null && vectors.size() > 0) {
       for (Object vector1 : vectors) {

--- a/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEConfigFileWriter.java
+++ b/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEConfigFileWriter.java
@@ -264,9 +264,9 @@ public final class PGEConfigFileWriter implements PGEConfigFileKeys,
 
         int rowNum = 0;
         for (List<Object> objects : matrix.getRows()) {
-          List rowValues = (List) objects;
+          List<?> rowValues = (List<?>) objects;
 
-          Element rowElem = document.createElement(MATRIX_ROW_TAG);
+          document.createElement(MATRIX_ROW_TAG);
 
           int colNum = 0;
           for (Object rowValue : rowValues) {

--- a/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEDataHandler.java
+++ b/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEDataHandler.java
@@ -22,7 +22,6 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 /**
  * 
@@ -36,18 +35,14 @@ import java.util.logging.Logger;
  */
 public class PGEDataHandler extends DefaultHandler implements PGEDataParseKeys {
 
-  /* our log stream */
-  private static final Logger LOG = Logger.getLogger(PGEDataHandler.class
-      .getName());
-
   /* scalars to be set as tags are encountered */
-  private Map scalars = new ConcurrentHashMap();
+  private Map<String, PGEScalar> scalars = new ConcurrentHashMap<String, PGEScalar>();
 
   /* vectors to be set as tags are encountered */
-  private Map vectors = new ConcurrentHashMap();
+  private Map<String, PGEVector> vectors = new ConcurrentHashMap<String, PGEVector>();
 
   /* matrices to be set as tags are encountered */
-  private Map matrices = new ConcurrentHashMap();
+  private Map<String, PGEMatrix> matrices = new ConcurrentHashMap<String, PGEMatrix>();
 
   /* the status of the parse handler */
   private int parseStatus = UNSET;
@@ -176,7 +171,7 @@ public class PGEDataHandler extends DefaultHandler implements PGEDataParseKeys {
   /**
    * @return the matrices
    */
-  public Map getMatrices() {
+  public Map<String, PGEMatrix> getMatrices() {
     return matrices;
   }
 
@@ -184,14 +179,14 @@ public class PGEDataHandler extends DefaultHandler implements PGEDataParseKeys {
    * @param matrices
    *          the matrices to set
    */
-  public void setMatrices(Map matrices) {
+  public void setMatrices(Map<String, PGEMatrix> matrices) {
     this.matrices = matrices;
   }
 
   /**
    * @return the scalars
    */
-  public Map getScalars() {
+  public Map<String, PGEScalar> getScalars() {
     return scalars;
   }
 
@@ -199,14 +194,14 @@ public class PGEDataHandler extends DefaultHandler implements PGEDataParseKeys {
    * @param scalars
    *          the scalars to set
    */
-  public void setScalars(Map scalars) {
+  public void setScalars(Map<String, PGEScalar> scalars) {
     this.scalars = scalars;
   }
 
   /**
    * @return the vectors
    */
-  public Map getVectors() {
+  public Map<String, PGEVector> getVectors() {
     return vectors;
   }
 
@@ -214,7 +209,7 @@ public class PGEDataHandler extends DefaultHandler implements PGEDataParseKeys {
    * @param vectors
    *          the vectors to set
    */
-  public void setVectors(Map vectors) {
+  public void setVectors(Map<String, PGEVector> vectors) {
     this.vectors = vectors;
   }
 

--- a/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEXMLFileUtils.java
+++ b/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEXMLFileUtils.java
@@ -53,7 +53,7 @@ public final class PGEXMLFileUtils {
   private static final Logger LOG = Logger.getLogger(PGEXMLFileUtils.class
       .getName());
 
-  public static Map getMatrixsAsMap(Element group)
+  public static Map<String, PGEMatrix> getMatrixsAsMap(Element group)
       throws PGEConfigFileException {
     // get the nodelist for the matrixs
     NodeList matrixs = group.getElementsByTagName("matrix");
@@ -63,7 +63,7 @@ public final class PGEXMLFileUtils {
       return Collections.emptyMap();
     }
 
-    Map matrixMap = new ConcurrentHashMap(matrixs.getLength());
+    Map<String, PGEMatrix> matrixMap = new ConcurrentHashMap<String, PGEMatrix>(matrixs.getLength());
 
     // for each matrix in the list, create a PGEMatrix with the name
     // attribute and the appropriate value
@@ -103,7 +103,7 @@ public final class PGEXMLFileUtils {
           pgeMatrix.setNumCols(colNodeList.getLength());
         }
 
-        List colList = new Vector(colNodeList.getLength());
+        List<Object> colList = new Vector<Object>(colNodeList.getLength());
 
         for (int k = 0; k < colNodeList.getLength(); k++) {
           Element colElement = (Element) colNodeList.item(k);
@@ -118,7 +118,7 @@ public final class PGEXMLFileUtils {
     return matrixMap;
   }
 
-  public static List getMatrixs(Element group) throws PGEConfigFileException {
+  public static List<PGEMatrix> getMatrixs(Element group) throws PGEConfigFileException {
     // get the nodelist for the matrixs
     NodeList matrixs = group.getElementsByTagName("matrix");
 
@@ -127,7 +127,7 @@ public final class PGEXMLFileUtils {
       return Collections.emptyList();
     }
 
-    List matrixList = new Vector(matrixs.getLength());
+    List<PGEMatrix> matrixList = new Vector<PGEMatrix>(matrixs.getLength());
 
     // for each matrix in the list, create a PGEMatrix with the name
     // attribute and the appropriate value
@@ -167,7 +167,7 @@ public final class PGEXMLFileUtils {
           pgeMatrix.setNumCols(colNodeList.getLength());
         }
 
-        List colList = new Vector(colNodeList.getLength());
+        List<Object> colList = new Vector<Object>(colNodeList.getLength());
 
         for (int k = 0; k < colNodeList.getLength(); k++) {
           Element colElement = (Element) colNodeList.item(k);
@@ -183,7 +183,7 @@ public final class PGEXMLFileUtils {
     return matrixList;
   }
 
-  public static Map getScalarsAsMap(Element group) {
+  public static Map<String, PGEScalar> getScalarsAsMap(Element group) {
     // get the nodelist for scalars
     NodeList scalars = group.getElementsByTagName("scalar");
 
@@ -192,7 +192,7 @@ public final class PGEXMLFileUtils {
       return Collections.emptyMap();
     }
 
-    Map scalarMap = new ConcurrentHashMap(scalars.getLength());
+    Map<String, PGEScalar> scalarMap = new ConcurrentHashMap<String, PGEScalar>(scalars.getLength());
 
     // for each scalar in the list, create a PGEScalar with the name
     // attribute, and appropriate value
@@ -211,7 +211,7 @@ public final class PGEXMLFileUtils {
     return scalarMap;
   }
 
-  public static List getScalars(Element group) {
+  public static List<PGEScalar> getScalars(Element group) {
     // get the nodelist for scalars
     NodeList scalars = group.getElementsByTagName("scalar");
 
@@ -220,7 +220,7 @@ public final class PGEXMLFileUtils {
       return Collections.emptyList();
     }
 
-    List scalarList = new Vector(scalars.getLength());
+    List<PGEScalar> scalarList = new Vector<PGEScalar>(scalars.getLength());
 
     // for each scalar in the list, create a PGEScalar with the name
     // attribute, and appropriate value
@@ -239,7 +239,7 @@ public final class PGEXMLFileUtils {
     return scalarList;
   }
 
-  public static Map getVectorsAsMap(Element group)
+  public static Map<String, PGEVector> getVectorsAsMap(Element group)
       throws PGEConfigFileException {
     // get the nodelist for scalars
     NodeList vectors = group.getElementsByTagName("vector");
@@ -249,7 +249,7 @@ public final class PGEXMLFileUtils {
       return Collections.emptyMap();
     }
 
-    Map vectorMap = new ConcurrentHashMap(vectors.getLength());
+    Map<String, PGEVector> vectorMap = new ConcurrentHashMap<String, PGEVector>(vectors.getLength());
 
     // for each vector in the list, create a PGEVector with the name
     // attribute, and appropriate value
@@ -270,7 +270,7 @@ public final class PGEXMLFileUtils {
             "There must be at least one element in a PGEVector!");
       }
 
-      List vecElemList = new Vector(vecElems.getLength());
+      List<Object> vecElemList = new Vector<Object>(vecElems.getLength());
 
       for (int j = 0; j < vecElems.getLength(); j++) {
         Element vecElem = (Element) vecElems.item(j);
@@ -284,7 +284,7 @@ public final class PGEXMLFileUtils {
     return vectorMap;
   }
 
-  public static List getVectors(Element group) throws PGEConfigFileException {
+  public static List<PGEVector> getVectors(Element group) throws PGEConfigFileException {
     // get the nodelist for scalars
     NodeList vectors = group.getElementsByTagName("vector");
 
@@ -293,7 +293,7 @@ public final class PGEXMLFileUtils {
       return Collections.emptyList();
     }
 
-    List vectorList = new Vector(vectors.getLength());
+    List<PGEVector> vectorList = new Vector<PGEVector>(vectors.getLength());
 
     // for each vector in the list, create a PGEVector with the name
     // attribute, and appropriate value
@@ -314,7 +314,7 @@ public final class PGEXMLFileUtils {
             "There must be at least one element in a PGEVector!");
       }
 
-      List vecElemList = new Vector(vecElems.getLength());
+      List<Object> vecElemList = new Vector<Object>(vecElems.getLength());
 
       for (int j = 0; j < vecElems.getLength(); j++) {
         Element vecElem = (Element) vecElems.item(j);
@@ -338,7 +338,7 @@ public final class PGEXMLFileUtils {
     InputStream xmlInputStream;
 
     try {
-      xmlInputStream = new File(xmlFile).toURL().openStream();
+      xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
     } catch (IOException e) {
       LOG.log(Level.WARNING, "IOException when getting input stream from ["
           + xmlFile + "]: returning null document root");

--- a/resource/pom.xml
+++ b/resource/pom.xml
@@ -58,7 +58,6 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.avro</groupId>
@@ -96,7 +95,6 @@ the License.
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <forkMode>pertest</forkMode>
           <useSystemClassLoader>false</useSystemClassLoader>
@@ -120,7 +118,6 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>
@@ -146,7 +143,6 @@ the License.
    <dependency>
     <groupId>com.thoughtworks.xstream</groupId>
     <artifactId>xstream</artifactId>
-    <version>1.3.1</version>
     <exclusions>
       <exclusion>
         <!-- xom is an optional dependency of xstream. Its also an Apache incompatible license -->
@@ -158,17 +154,10 @@ the License.
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-ipc</artifactId>
-      <version>1.7.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.oodt</groupId>
-      <artifactId>cas-metadata</artifactId>
-      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/resource/src/main/java/org/apache/oodt/cas/resource/examples/TestResmgr.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/examples/TestResmgr.java
@@ -22,7 +22,7 @@ package org.apache.oodt.cas.resource.examples;
 
 import org.apache.oodt.cas.resource.structs.Job;
 import org.apache.oodt.cas.resource.structs.NameValueJobInput;
-import org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient;
+import org.apache.oodt.cas.resource.system.AvroRpcResourceManagerClient;
 
 import java.net.URL;
 import java.util.logging.Level;
@@ -44,13 +44,13 @@ public class TestResmgr {
   public static void main(String[] Args) {
 
     if (Args.length != 1) {
-      System.err.println("Specify a XmlRpcResourceManager Host");
+      System.err.println("Specify a AvroRpcResourceManager Host");
       System.exit(1);
     }
 
     try {
       URL managerUrl = new URL(Args[0]);
-      XmlRpcResourceManagerClient client = new XmlRpcResourceManagerClient(
+      AvroRpcResourceManagerClient client = new AvroRpcResourceManagerClient(
           managerUrl);
 
       Job hw1 = new Job("JobOne", "HelloWorldJob",

--- a/resource/src/main/java/org/apache/oodt/cas/resource/jobqueue/JobQueue.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/jobqueue/JobQueue.java
@@ -65,7 +65,7 @@ public interface JobQueue {
    * @throws JobQueueException
    *           If there is any error obtaining the queued jobs.
    */
-  List getQueuedJobs();
+  List<JobSpec> getQueuedJobs();
 
   /**
    * Purges all {@link JobSpec}s from the queue.

--- a/resource/src/main/java/org/apache/oodt/cas/resource/monitor/Monitor.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/monitor/Monitor.java
@@ -57,7 +57,7 @@ public interface Monitor {
    *           If any error occurs getting the {@link List} of
    *           {@link ResourceNode}s.
    */
-  List getNodes() throws MonitorException;
+  List<ResourceNode> getNodes() throws MonitorException;
   
   
   /**

--- a/resource/src/main/java/org/apache/oodt/cas/resource/structs/AvroTypeFactory.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/structs/AvroTypeFactory.java
@@ -17,9 +17,6 @@
 
 package org.apache.oodt.cas.resource.structs;
 
-import org.apache.avro.ipc.Responder;
-import org.apache.avro.reflect.AvroName;
-import org.apache.oodt.cas.metadata.Metadata;
 import org.apache.oodt.cas.resource.structs.avrotypes.*;
 import org.apache.oodt.cas.resource.util.GenericResourceManagerObjectFactory;
 

--- a/resource/src/main/java/org/apache/oodt/cas/resource/structs/JobInput.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/structs/JobInput.java
@@ -22,7 +22,6 @@ package org.apache.oodt.cas.resource.structs;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.oodt.cas.metadata.Metadata;
 //OODT imports
 import org.apache.oodt.cas.resource.util.Configurable;
 import org.apache.oodt.cas.resource.util.XmlRpcWriteable;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/structs/JobSpecSerializer.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/structs/JobSpecSerializer.java
@@ -17,6 +17,7 @@
 package org.apache.oodt.cas.resource.structs;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * A class used to serialize and de-serialize a job spec
@@ -71,7 +72,12 @@ public class JobSpecSerializer implements java.io.Serializable {
         tmp.setStatus(status);
         //Read in job input, using proper class
         Class<?> clazz = Class.forName(jobInputClassName);
-        JobInput input = ((JobInput)clazz.newInstance());
+        JobInput input = null;
+        try {
+          input = ((JobInput)clazz.getConstructor().newInstance());
+        } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+          e.printStackTrace();
+        }
         input.read(jobInput);
         JobSpec spec = new JobSpec();
         spec.setIn(input);

--- a/resource/src/main/java/org/apache/oodt/cas/resource/structs/NameValueJobInput.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/structs/NameValueJobInput.java
@@ -78,7 +78,7 @@ public class NameValueJobInput implements JobInput {
       return;
     }
 
-    Map readable = (Map) in;
+    Map<?, ?> readable = (Map<?, ?>) in;
     for (Object o : readable.keySet()) {
       String key = (String) o;
       String value = (String) readable.get(key);
@@ -93,7 +93,7 @@ public class NameValueJobInput implements JobInput {
    * @see org.apache.oodt.cas.resource.util.XmlRpcWriteable#write()
    */
   public Object write() {
-    Map writeable = new ConcurrentHashMap();
+    Map<String, String> writeable = new ConcurrentHashMap<String, String>();
     if (props != null && props.size() > 0) {
       for (Object o : props.keySet()) {
         String key = (String) o;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
@@ -178,7 +178,7 @@ public class AvroRpcResourceManager implements org.apache.oodt.cas.resource.stru
     @Override
     public List<AvroResourceNode> getNodes() throws AvroRemoteException {
 
-        List resNodes = null;
+        List<ResourceNode> resNodes = null;
         try {
             resNodes = scheduler.getMonitor().getNodes();
         } catch (MonitorException e) {
@@ -233,7 +233,7 @@ public class AvroRpcResourceManager implements org.apache.oodt.cas.resource.stru
         try {
 
             // get a sorted list of nodes
-            List nodes = scheduler.getMonitor().getNodes();
+            List<ResourceNode> nodes = scheduler.getMonitor().getNodes();
             Collections.sort(nodes, new ResourceNodeComparator());
 
             // formulate the report string
@@ -260,7 +260,7 @@ public class AvroRpcResourceManager implements org.apache.oodt.cas.resource.stru
 
     public List<AvroJob> getQueuedJobs() {
         List<AvroJob> jobs = new ArrayList<>();
-        List jobSpecs = this.scheduler.getJobQueue().getQueuedJobs();
+        List<JobSpec> jobSpecs = this.scheduler.getJobQueue().getQueuedJobs();
 
         if (jobSpecs != null && jobSpecs.size() > 0) {
             for (Object jobSpec : jobSpecs) {
@@ -280,7 +280,7 @@ public class AvroRpcResourceManager implements org.apache.oodt.cas.resource.stru
 
             // get a sorted list of all nodes, since the report should be
             // alphabetically sorted by node
-            List resNodes = scheduler.getMonitor().getNodes();
+            List<ResourceNode> resNodes = scheduler.getMonitor().getNodes();
             if (resNodes.size() == 0) {
                 throw new MonitorException(
                         "No jobs can be executing, as there are no nodes in the Monitor");

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
@@ -26,6 +26,7 @@ import org.apache.oodt.cas.resource.structs.AvroTypeFactory;
 import org.apache.oodt.cas.resource.structs.Job;
 import org.apache.oodt.cas.resource.structs.JobInput;
 import org.apache.oodt.cas.resource.structs.ResourceNode;
+import org.apache.oodt.cas.resource.structs.avrotypes.AvroJob;
 import org.apache.oodt.cas.resource.structs.avrotypes.ResourceManager;
 import org.apache.oodt.cas.resource.structs.exceptions.JobExecutionException;
 import org.apache.oodt.cas.resource.structs.exceptions.JobQueueException;
@@ -46,7 +47,7 @@ public class AvroRpcResourceManagerClient implements ResourceManagerClient {
 
     /* our log stream */
     private static Logger LOG = Logger
-            .getLogger(XmlRpcResourceManagerClient.class.getName());
+            .getLogger(AvroRpcResourceManagerClient.class.getName());
 
     /* resource manager url */
     private URL resMgrUrl = null;
@@ -197,7 +198,7 @@ public class AvroRpcResourceManagerClient implements ResourceManagerClient {
     }
 
     @Override
-    public List getNodes() throws MonitorException {
+    public List<ResourceNode> getNodes() throws MonitorException {
         try {
             return AvroTypeFactory.getListResourceNode(proxy.getNodes());
         } catch (AvroRemoteException e) {
@@ -325,7 +326,7 @@ public class AvroRpcResourceManagerClient implements ResourceManagerClient {
     }
 
     @Override
-    public List getQueuedJobs() throws JobQueueException {
+    public List<AvroJob> getQueuedJobs() throws JobQueueException {
         try {
             return proxy.getQueuedJobs();
         } catch (AvroRemoteException e) {

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/XmlRpcResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/XmlRpcResourceManagerClient.java
@@ -48,7 +48,7 @@ import java.util.logging.Logger;
 /**
  * @author mattmann
  * @version $Revision$
- * @deprecated soon be replaced by avro-rpc
+ * @deprecated use {@link AvroRpcResourceManagerClient}
  * <p>
  * The XML RPC based resource manager client.
  * </p>

--- a/resource/src/test/java/org/apache/oodt/cas/resource/system/MockXmlRpcResourceManagerClient.java
+++ b/resource/src/test/java/org/apache/oodt/cas/resource/system/MockXmlRpcResourceManagerClient.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
  * 
  * @author bfoster (Brian Foster)
  */
+@SuppressWarnings("deprecation")
 public class MockXmlRpcResourceManagerClient extends
       XmlRpcResourceManagerClient {
 

--- a/resource/src/test/java/org/apache/oodt/cas/resource/system/TestAvroRpcResourceManager.java
+++ b/resource/src/test/java/org/apache/oodt/cas/resource/system/TestAvroRpcResourceManager.java
@@ -111,8 +111,6 @@ public class TestAvroRpcResourceManager {
     private void generateTestConfiguration() throws IOException {
         Properties config = new Properties();
 
-        String propertiesFile = "." + File.separator + "src" + File.separator +
-                "test" + File.separator + "resources" + File.separator + "test.resource.properties";
         System.getProperties().load(new FileInputStream(new File("./src/test/resources/test.resource.properties")));
 
         // stage policy

--- a/resource/src/test/java/org/apache/oodt/cas/resource/system/TestAvroRpcResourceManagerClient.java
+++ b/resource/src/test/java/org/apache/oodt/cas/resource/system/TestAvroRpcResourceManagerClient.java
@@ -19,6 +19,7 @@ package org.apache.oodt.cas.resource.system;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.oodt.cas.resource.structs.ResourceNode;
+import org.apache.oodt.cas.resource.structs.avrotypes.AvroJob;
 import org.apache.oodt.cas.resource.structs.exceptions.JobQueueException;
 import org.apache.oodt.cas.resource.structs.exceptions.JobRepositoryException;
 import org.apache.oodt.cas.resource.structs.exceptions.MonitorException;
@@ -32,7 +33,6 @@ import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Properties;
 
@@ -104,7 +104,7 @@ public class TestAvroRpcResourceManagerClient {
 
     @Test
     public void testGetNodes() throws MonitorException {
-        List<Hashtable> nodes = rmc.getNodes();
+        List<ResourceNode> nodes = rmc.getNodes();
 
         assertThat(nodes, is(not(nullValue())));
         assertThat(nodes, hasSize(1));
@@ -177,7 +177,7 @@ public class TestAvroRpcResourceManagerClient {
 
     @Test
     public void testQueuedJobs() throws JobQueueException {
-        List jobs = rmc.getQueuedJobs();
+        List<AvroJob> jobs = rmc.getQueuedJobs();
 
         assertThat(jobs, is(not(nullValue())));
 

--- a/resource/src/test/java/org/apache/oodt/cas/resource/system/TestXmlRpcResourceManager.java
+++ b/resource/src/test/java/org/apache/oodt/cas/resource/system/TestXmlRpcResourceManager.java
@@ -48,6 +48,7 @@ public class TestXmlRpcResourceManager extends TestCase {
 
   private File tmpPolicyDir;
 
+  @SuppressWarnings("deprecation")
   private XmlRpcResourceManager rm;
 
   private static final int RM_PORT = 50001;
@@ -55,6 +56,7 @@ public class TestXmlRpcResourceManager extends TestCase {
   /**
    * @since OODT-182
    */
+  @SuppressWarnings("deprecation")
   public void testDynSetNodeCapacity() {
     XmlRpcResourceManagerClient rmc = null;
     try {
@@ -85,6 +87,7 @@ public class TestXmlRpcResourceManager extends TestCase {
    *
    * @see junit.framework.TestCase#setUp()
    */
+  @SuppressWarnings("deprecation")
   @Override
   protected void setUp() throws Exception {
     System.out.println(NameValueJobInput.class.getCanonicalName());
@@ -98,6 +101,7 @@ public class TestXmlRpcResourceManager extends TestCase {
    *
    * @see junit.framework.TestCase#tearDown()
    */
+  @SuppressWarnings("deprecation")
   @Override
   protected void tearDown() throws Exception {
     this.rm.shutdown();

--- a/resource/src/test/java/org/apache/oodt/cas/resource/system/TestXmlRpcResourceManagerClient.java
+++ b/resource/src/test/java/org/apache/oodt/cas/resource/system/TestXmlRpcResourceManagerClient.java
@@ -52,6 +52,7 @@ public class TestXmlRpcResourceManagerClient {
     private static ResourceManagerClient rmc;
     private static ResourceManager rm;
 
+    @SuppressWarnings("deprecation")
     @BeforeClass
     public static void setUp() throws Exception {
         generateTestConfiguration();

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -55,13 +55,11 @@ the License.
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.8.1</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.avro/avro-ipc -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-ipc</artifactId>
-      <version>1.8.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -219,7 +217,7 @@ the License.
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkMode>pertest</forkMode>
+          <reuseForks>true</reuseForks>
           <useSystemClassLoader>false</useSystemClassLoader>
           <systemProperties>
             <property>
@@ -241,7 +239,6 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/engine/IterativeWorkflowProcessorThread.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/engine/IterativeWorkflowProcessorThread.java
@@ -112,7 +112,7 @@ public class IterativeWorkflowProcessorThread implements WorkflowStatus, CoreMet
 
   public IterativeWorkflowProcessorThread(WorkflowInstance wInst, WorkflowInstanceRepository instRep, URL wParentUrl) {
     workflowInst = wInst;
-    taskIterator = workflowInst.getWorkflow().getTasks().iterator();
+    taskIterator = workflowInst.getParentChildWorkflow().getTasks().iterator();
     this.instanceRepository = instRep;
 
     /* start out the gates running */
@@ -130,7 +130,7 @@ public class IterativeWorkflowProcessorThread implements WorkflowStatus, CoreMet
 
     wmgrParentUrl = wParentUrl;
     logger.info("Thread created for workflowInstance: {}[{}], instanceRepository class: {}, wmgrParentUrl: {}",
-            workflowInst.getId(), workflowInst.getWorkflow().getName(),
+            workflowInst.getId(), workflowInst.getParentChildWorkflow().getName(),
             instanceRepository.getClass().getName(), wmgrParentUrl);
   }
 

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/engine/runner/AsynchronousLocalEngineRunner.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/engine/runner/AsynchronousLocalEngineRunner.java
@@ -107,7 +107,7 @@ public class AsynchronousLocalEngineRunner extends AbstractEngineRunnerBase {
        * 
        * @see java.lang.Thread#interrupt()
        */
-      @SuppressWarnings("deprecation")
+      @SuppressWarnings("removal")
       @Override
       public void interrupt() {
         super.interrupt();
@@ -148,7 +148,6 @@ public class AsynchronousLocalEngineRunner extends AbstractEngineRunnerBase {
    */
   @Override
   public boolean hasOpenSlots(TaskProcessor taskProcessor) {
-    // TODO Auto-generated method stub
     return true;
   }
 
@@ -157,7 +156,7 @@ public class AsynchronousLocalEngineRunner extends AbstractEngineRunnerBase {
    */
   @Override
   public void setInstanceRepository(WorkflowInstanceRepository instRep) {
-    this.instRep = instRep;    
+    this.instRep = instRep;
   }
 
 }

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/instrepo/DataSourceWorkflowInstanceRepository.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/instrepo/DataSourceWorkflowInstanceRepository.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.oodt.cas.workflow.instrepo;
 
 //OODT imports
@@ -805,7 +804,7 @@ public class DataSourceWorkflowInstanceRepository extends
                 int numGrabbed;
                 if(pageNum == 1){
                     numGrabbed = 1;
-                    wInstIds.add(rs.getString("workflow_instance_id"));                    
+                    wInstIds.add(rs.getString("workflow_instance_id"));
                 }
                 else{
                     numGrabbed = 0;
@@ -813,7 +812,7 @@ public class DataSourceWorkflowInstanceRepository extends
 
                 if(pageNum != 1){
                     // now move the cursor to the correct position
-                    rs.relative(startNum);                    
+                    rs.relative(startNum);
                 }
 
                 // grab the rest

--- a/workflow/src/test/java/org/apache/oodt/cas/workflow/system/TestXmlRpcWorkflowManager.java
+++ b/workflow/src/test/java/org/apache/oodt/cas/workflow/system/TestXmlRpcWorkflowManager.java
@@ -45,6 +45,7 @@ public class TestXmlRpcWorkflowManager extends TestCase {
 
   private static final int WM_PORT = 50002;
 
+  @SuppressWarnings("deprecation")
   private XmlRpcWorkflowManager wmgr;
 
   private String luceneCatLoc;
@@ -52,6 +53,7 @@ public class TestXmlRpcWorkflowManager extends TestCase {
   private static final Logger LOG = Logger
       .getLogger(TestXmlRpcWorkflowManager.class.getName());
 
+  @SuppressWarnings("deprecation")
   public void testGetWorkflowInstances() {
 
     List workflowInsts = null;
@@ -80,6 +82,7 @@ public class TestXmlRpcWorkflowManager extends TestCase {
 
   }
 
+  @SuppressWarnings("deprecation")
   private void startWorkflow() {
     XmlRpcWorkflowManagerClient client = null;
     try {
@@ -98,6 +101,7 @@ public class TestXmlRpcWorkflowManager extends TestCase {
 
   }
 
+  @SuppressWarnings("deprecation")
   private void startXmlRpcWorkflowManager() {
     System.setProperty("java.util.logging.config.file", new File(
         "./src/main/resources/logging.properties").getAbsolutePath());

--- a/workflow/src/test/java/org/apache/oodt/cas/workflow/system/distributed/TestDistributedXmlRpcWorkflowManager.java
+++ b/workflow/src/test/java/org/apache/oodt/cas/workflow/system/distributed/TestDistributedXmlRpcWorkflowManager.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("deprecation")
 public class TestDistributedXmlRpcWorkflowManager extends AbstractDistributedConfigurationTest {
 
     private static final int WM_PORT = 50002;


### PR DESCRIPTION
PR addresses https://issues.apache.org/jira/browse/OODT-990.
The more I dug here, the more unmanageable this patch became/is becoming so what is represented here is a cleanup patch (complying with Type safety, removing unused imports, etc.) as well as addressing use of deprecated API's peppered throughout the OODT codebase.

I should mention that when I run the tests from the parent pom, [TestXmlRpcWorkflowManager.java](https://github.com/apache/oodt/blob/master/workflow/src/test/java/org/apache/oodt/cas/workflow/system/TestXmlRpcWorkflowManager.java) hangs. I would like others to let me know if it hangs when they test this patch.