### PR TITLE
OODT-994 Replace deprecated -Djava.ext.dirs with -classpath

### DIFF
--- a/config/src/main/scripts/conf-publisher
+++ b/config/src/main/scripts/conf-publisher
@@ -28,7 +28,7 @@ echo -n "Starting Configuration Publisher\n"
 $JAVA_HOME/bin/java \
         	-cp ${LIB_DEPS} \
         	-Dlog4j.configurationFile=${CONF_HOME}/etc/log4j2.xml \
-        	-Djava.ext.dirs=. \
+        	-classpath=. \
             -Djava.util.logging.config.file=${CONF_HOME}/etc/logging.properties \
             -Dorg.apache.oodt.cas.cli.action.spring.config=${CONF_HOME}/policy/cmd-line-actions.xml \
             -Dorg.apache.oodt.cas.cli.option.spring.config=${CONF_HOME}/policy/cmd-line-options.xml \

--- a/crawler/src/main/bin/crawlctl
+++ b/crawler/src/main/bin/crawlctl
@@ -18,4 +18,4 @@
 java \
     -Dlog4j.configurationFile=../etc/log4j2.xml \
     -Djava.util.logging.config.file=../etc/logging.properties \
-    -Djava.ext.dirs=../lib org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $*
+    -classpath=../lib org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $*

--- a/crawler/src/main/bin/crawler_launcher
+++ b/crawler/src/main/bin/crawler_launcher
@@ -25,7 +25,7 @@ fi
 export JAVA_HOME
 
 $JAVA_HOME/bin/java \
-        -Djava.ext.dirs=../lib \
+        -classpath=../lib \
         -Dlog4j.configurationFile=../etc/log4j2.xml \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.crawl.bean.repo=../policy/crawler-config.xml \

--- a/filemgr/src/main/bin/query_tool
+++ b/filemgr/src/main/bin/query_tool
@@ -20,4 +20,4 @@
 # NOTE: This has been deprecated... use SqlQuery and LuceneQuery actions instead.
 ############################################
 
-$JAVA_HOME/bin/java -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.QueryTool "$@"
+$JAVA_HOME/bin/java -classpath=../lib org.apache.oodt.cas.filemgr.tools.QueryTool "$@"

--- a/filemgr/src/main/resources/bash_aliases.txt
+++ b/filemgr/src/main/resources/bash_aliases.txt
@@ -22,9 +22,9 @@
 # For complete documentation see: 
 #     https://cwiki.apache.org/confluence/display/OODT/BASH+and+TCSH+shell+tools+for+File+Manager
 #
-alias lucenequery="java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --lucene -query "
-alias sqlquery="java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --sql -query "
-alias fmdel="java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl http://localhost:9000 --read"
-alias metdump="java -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.MetadataDumper --url http://localhost:9000 --out . --productId "
+alias lucenequery="java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -classpath=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --lucene -query "
+alias sqlquery="java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -classpath=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --sql -query "
+alias fmdel="java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -classpath=../lib org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl http://localhost:9000 --read"
+alias metdump="java -classpath=../lib org.apache.oodt.cas.filemgr.tools.MetadataDumper --url http://localhost:9000 --out . --productId "
 #
 ################################################

--- a/filemgr/src/main/resources/tcsh_aliases.txt
+++ b/filemgr/src/main/resources/tcsh_aliases.txt
@@ -22,9 +22,9 @@
 # For complete documentation see: 
 #     https://cwiki.apache.org/confluence/display/OODT/BASH+and+TCSH+shell+tools+for+File+Manager
 #
-alias lucenequery 'java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --lucene -query '
-alias sqlquery 'java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --sql -query '
-alias fmdel 'java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl http://localhost:9000 --read'
-alias metdump 'java -Djava.ext.dirs=../lib org.apache.oodt.cas.filemgr.tools.MetadataDumper --url http://localhost:9000 --out . --productId '
+alias lucenequery 'java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -classpath=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --lucene -query '
+alias sqlquery 'java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -classpath=../lib org.apache.oodt.cas.filemgr.tools.QueryTool --url http://localhost:9000 --sql -query '
+alias fmdel 'java -Dorg.apache.oodt.cas.filemgr.properties=../etc/filemgr.properties -classpath=../lib org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl http://localhost:9000 --read'
+alias metdump 'java -classpath=../lib org.apache.oodt.cas.filemgr.tools.MetadataDumper --url http://localhost:9000 --out . --productId '
 #
 ################################################

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/src/main/resources/bin/crawlctl
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/src/main/resources/bin/crawlctl
@@ -15,4 +15,4 @@
 # under the License.    
 ##########################################################################
 
-java -Djava.util.logging.config.file=../etc/logging.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $@
+java -Djava.util.logging.config.file=../etc/logging.properties -classpath=../lib org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $@

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/src/main/resources/bin/crawler_launcher
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/src/main/resources/bin/crawler_launcher
@@ -68,7 +68,7 @@ fi
 cd "$CRAWLER_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-   -Djava.ext.dirs="$CRAWLER_HOME"/lib \
+   -classpath="$CRAWLER_HOME"/lib \
    -Djava.util.logging.config.file="$CRAWLER_HOME"/etc/logging.properties \
    -Dorg.apache.oodt.cas.crawl.bean.repo=file:"$CRAWLER_HOME"/policy/crawler-config.xml \
    -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$CRAWLER_HOME"/policy/cmd-line-actions.xml \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/src/main/resources/bin/filemgr
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/src/main/resources/bin/filemgr
@@ -81,7 +81,7 @@ if [ "$1" = "start" ]; then
   cd "$FILEMGR_HOME"/bin
   
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-    -Djava.ext.dirs="$FILEMGR_HOME"/lib \
+    -classpath="$FILEMGR_HOME"/lib \
     -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/src/main/resources/bin/filemgr-client
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/src/main/resources/bin/filemgr-client
@@ -69,7 +69,7 @@ fi
 cd "$FILEMGR_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-  -Djava.ext.dirs="$FILEMGR_HOME"/lib \
+  -classpath="$FILEMGR_HOME"/lib \
   -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
   -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-actions.xml \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/src/main/resources/bin/pcs_ll
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/src/main/resources/bin/pcs_ll
@@ -42,6 +42,6 @@ set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
 java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
-    -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../../workflow/lib \
+    -classpath=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../../workflow/lib \
 	org.apache.oodt.pcs.tools.PCSLongLister \
 	$FILEMGR_URL $DIR_PATH/../policy/pcs-ll-conf.xml $argv[2-$#argv]

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/src/main/resources/bin/pcs_stat
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/src/main/resources/bin/pcs_stat
@@ -68,7 +68,7 @@ set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
 java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
-    -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../workflow/lib:$DIR_PATH/../../resmgr/lib \
+    -classpath=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../workflow/lib:$DIR_PATH/../../resmgr/lib \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSHealthMonitor \
 	$FILEMGR_URL \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/src/main/resources/bin/pcs_trace
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/src/main/resources/bin/pcs_trace
@@ -29,7 +29,7 @@ if ( $#argv != 1 ) then
 	echo "Usage: $0 <product>"
 	exit 1
 else
-	java -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../../workflow/lib \
+	java -classpath=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../../workflow/lib \
     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSTrace \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/batch_stub
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/batch_stub
@@ -25,7 +25,7 @@ if ( $#argv != 1 ) then
         echo "Usage: $0 <port>"
         exit 1
 else
-        java -Djava.ext.dirs=../lib \
+        java -classpath=../lib \
         org.apache.oodt.cas.resource.system.extern.XmlRpcBatchStub \
         -Dorg.apache.oodt.cas.pge.task.metkeys.legacyMode="true" \
         -Dorg.apache.oodt.cas.pge.task.status.legacyMode="true" \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/resmgr
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/resmgr
@@ -87,7 +87,7 @@ if [ "$1" = "start" ]; then
   cd "$RESMGR_HOME"/bin
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-    -Djava.ext.dirs="$RESMGR_HOME"/lib \
+    -classpath="$RESMGR_HOME"/lib \
     -Djava.util.logging.config.file="$RESMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.resource.properties="$RESMGR_HOME"/etc/resource.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/resmgr-client
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/src/main/resources/bin/resmgr-client
@@ -26,7 +26,7 @@ fi
 export JAVA_HOME
 
 $JAVA_HOME/bin/java \
-        -Djava.ext.dirs=../lib \
+        -classpath=../lib \
         -Dorg.apache.oodt.cas.resource.properties=../etc/resource.properties \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/bin/wmgr
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/bin/wmgr
@@ -80,7 +80,7 @@ if [ "$1" = "start" ]; then
   cd "$WORKFLOW_HOME"/bin
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-    -Djava.ext.dirs="$WORKFLOW_HOME"/lib \
+    -classpath="$WORKFLOW_HOME"/lib \
     -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.workflow.properties="$WORKFLOW_HOME"/etc/workflow.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/bin/wmgr-client
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/src/main/resources/bin/wmgr-client
@@ -68,7 +68,7 @@ fi
 cd "$WORKFLOW_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-  -Djava.ext.dirs="$WORKFLOW_HOME"/lib \
+  -classpath="$WORKFLOW_HOME"/lib \
   -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-options.xml \

--- a/pcs/core/src/main/bin/pcs_ll
+++ b/pcs/core/src/main/bin/pcs_ll
@@ -42,6 +42,6 @@ set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
 java -Djava.util.logging.config.file=$DIR_PATH/../aux/pcs/pcs.logging.properties \
-    -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../filemgr/lib:$DIR_PATH/../workflow/lib \
+    -classpath=$DIR_PATH/../lib:$DIR_PATH/../filemgr/lib:$DIR_PATH/../workflow/lib \
 	org.apache.oodt.pcs.tools.PCSLongLister \
 	$FILEMGR_URL $DIR_PATH/../aux/pcs/pcs-ll-conf.xml $argv[2-$#argv]

--- a/pcs/core/src/main/bin/pcs_stat
+++ b/pcs/core/src/main/bin/pcs_stat
@@ -68,7 +68,7 @@ set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
 java -Djava.util.logging.config.file=$DIR_PATH/../aux/pcs/pcs.logging.properties \
-    -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../filemgr/lib:$DIR_PATH/../workflow/lib:../resmgr/lib \
+    -classpath=$DIR_PATH/../lib:$DIR_PATH/../filemgr/lib:$DIR_PATH/../workflow/lib:../resmgr/lib \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSHealthMonitor \
 	$FILEMGR_URL \

--- a/pcs/core/src/main/bin/pcs_trace
+++ b/pcs/core/src/main/bin/pcs_trace
@@ -29,7 +29,7 @@ if ( $#argv != 1 ) then
 	echo "Usage: $0 <product>"
 	exit 1
 else
-	java -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../filemgr/lib:$DIR_PATH/../workflow/lib \
+	java -classpath=$DIR_PATH/../lib:$DIR_PATH/../filemgr/lib:$DIR_PATH/../workflow/lib \
     -Djava.util.logging.config.file=$DIR_PATH/../aux/pcs/pcs.logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSTrace \

--- a/pge/src/main/bin/pgetask
+++ b/pge/src/main/bin/pgetask
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.    
 
-$JAVA_HOME/bin/java -Djava.ext.dirs=../lib \
+$JAVA_HOME/bin/java -classpath=../lib \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl \
         org.apache.oodt.cas.pge.PGETask --metadata ../etc/examples/WorkflowMgrInput/pcs-pge-dyn-metadata.met \

--- a/resource/src/main/bin/batch_stub
+++ b/resource/src/main/bin/batch_stub
@@ -25,7 +25,7 @@ if ( $#argv != 1 ) then
         echo "Usage: $0 <port>"
         exit 1
 else
-        java -Djava.ext.dirs=../lib \
+        java -classpath=../lib \
         -Dorg.apache.oodt.cas.pge.task.metkeys.legacyMode="true" \
 	-Dorg.apache.oodt.cas.pge.task.status.legacyMode="true" \
         org.apache.oodt.cas.resource.system.extern.XmlRpcBatchStub \

--- a/resource/src/main/bin/resmgr
+++ b/resource/src/main/bin/resmgr
@@ -48,7 +48,7 @@ export PATH
 case "$1" in
   start)
         echo -n "Starting cas resource manager: "
-        $JAVA_HOME/bin/java -Djava.ext.dirs=${CAS_RESMGR_HOME}/lib \
+        $JAVA_HOME/bin/java -classpath=${CAS_RESMGR_HOME}/lib \
         -Djava.util.logging.config.file=${CAS_RESMGR_HOME}/etc/logging.properties \
         -Dorg.apache.oodt.cas.resource.properties=${CAS_RESMGR_PROPS} \
         org.apache.oodt.cas.resource.system.ResourceManagerMain --portNum $SERVER_PORT &

--- a/resource/src/main/bin/resmgr-client
+++ b/resource/src/main/bin/resmgr-client
@@ -26,7 +26,7 @@ fi
 export JAVA_HOME
 
 $JAVA_HOME/bin/java \
-        -Djava.ext.dirs=../lib \
+        -classpath=../lib \
         -Dorg.apache.oodt.cas.resource.properties=../etc/resource.properties \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \

--- a/resource/src/site/xdoc/user/index.xml
+++ b/resource/src/site/xdoc/user/index.xml
@@ -401,7 +401,7 @@ the License.
       <p>The command to run the job, assuming that you started the Resource Manager on the default port of <code>9002</code>:</p>
 
       <source>
-      java -Djava.ext.dirs=../lib org.apache.oodt.cas.resource.tools.JobSubmitter \
+      java -classpath=../lib org.apache.oodt.cas.resource.tools.JobSubmitter \
                        --rUrl http://localhost:9002 \
                        --file /usr/local/resmgr/examples/exJob.xml
       </source>

--- a/webapp/fmprod/src/site/xdoc/tutorial/index.xml
+++ b/webapp/fmprod/src/site/xdoc/tutorial/index.xml
@@ -487,7 +487,7 @@ acceptableTypes.add("image/*");</source>
 
 	<p>Here's an example:</p>
 
-	<source>% <b>java -Djava.ext.dirs=. \
+	<source>% <b>java -classpath=. \
   org.apache.oodt.xmlquery.XMLQuery \
   -expr donutsEaten \&gt; 5 AND RETURN = episodeNumber</b>
 kwdQueryString: donutsEaten &gt; 5 AND RETURN = episodeNumber

--- a/webapp/fmprod/src/site/xdoc/tutorials/lh/index.xml
+++ b/webapp/fmprod/src/site/xdoc/tutorials/lh/index.xml
@@ -615,7 +615,7 @@ FileHandler.class</source>
       </p>
 
       <source>#!/bin/sh
-exec java -Djava.ext.dirs=$PS_HOME/lib \
+exec java -classpath=$PS_HOME/lib \
     -Dhandlers=ConstantHandler,FileHandler \
     jpl.eda.ExecServer \
     jpl.eda.product.rmi.ProductServiceImpl \

--- a/webapp/fmprod/src/site/xdoc/tutorials/ps/index.xml
+++ b/webapp/fmprod/src/site/xdoc/tutorials/ps/index.xml
@@ -195,7 +195,7 @@ total 312
 
 	<p>Here's the <code>rmi-reg</code> script:</p>
 	<source>#!/bin/sh
-exec java -Djava.ext.dirs=$PS_HOME/lib \
+exec java -classpath=$PS_HOME/lib \
     gov.nasa.jpl.oodt.rmi.RMIRegistry</source>
 
 	<p>This script tells the Java virtual machine to find
@@ -268,7 +268,7 @@ total 376
 	</p>
 
 	<source>#!/bin/sh
-exec java -Djava.ext.dirs=$PS_HOME/lib \
+exec java -classpath=$PS_HOME/lib \
     jpl.eda.ExecServer \
     jpl.eda.product.rmi.ProductServiceImpl \
     urn:eda:rmi:MyProductService</source>
@@ -382,7 +382,7 @@ if [ $# -ne 1 ]; then
    exit 1
 fi
 
-exec java -Djava.ext.dirs=$PS_HOME/lib \
+exec java -classpath=$PS_HOME/lib \
      jpl.eda.product.ProductClient \
      -out \
      urn:eda:rmi:MyProductService \

--- a/webapp/fmprod/src/site/xdoc/tutorials/qh/index.xml
+++ b/webapp/fmprod/src/site/xdoc/tutorials/qh/index.xml
@@ -569,7 +569,7 @@ ConstantHandler.class</source>
       </p>
 
       <source>#!/bin/sh
-exec java -Djava.ext.dirs=$PS_HOME/lib \
+exec java -classpath=$PS_HOME/lib \
     -Dhandlers=ConstantHandler \
     jpl.eda.ExecServer \
     jpl.eda.product.rmi.ProductServiceImpl \

--- a/workflow/src/main/bin/wmgr
+++ b/workflow/src/main/bin/wmgr
@@ -48,7 +48,7 @@ export PATH
 case "$1" in
   start)
         echo -n "Starting cas workflow manager: "
-        $JAVA_HOME/bin/java -Djava.ext.dirs=${CAS_WORKFLOW_HOME}/lib \
+        $JAVA_HOME/bin/java -classpath=${CAS_WORKFLOW_HOME}/lib \
         -Dlog4j.configurationFile=${CAS_WORKFLOW_HOME}/etc/log4j2.xml \
         -Djava.util.logging.config.file=${CAS_WORKFLOW_HOME}/etc/logging.properties \
         -Dorg.apache.oodt.cas.workflow.properties=${CAS_WORKFLOW_PROPS} \

--- a/workflow/src/main/bin/wmgr-client
+++ b/workflow/src/main/bin/wmgr-client
@@ -24,7 +24,7 @@ fi
 export JAVA_HOME
 
 $JAVA_HOME/bin/java \
-        -Djava.ext.dirs=../lib \
+        -classpath=../lib \
         -Dlog4j.configurationFile=../etc/log4j2.xml \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \


### PR DESCRIPTION
Issue addresses https://issues.apache.org/jira/browse/OODT-994

My environment is as follows
```
Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T11:33:14-07:00)
Maven home: /usr/local/Cellar/maven/3.5.4/libexec
Java version: 10.0.2, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk-10.0.2.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.12.6", arch: "x86_64", family: "Mac"
```