### PR TITLE
OODT-998 Fix for "The startup script of cas-filemgr fails if distribution is located in a path with blank spaces"

### DIFF
--- a/filemgr/src/main/bin/filemgr
+++ b/filemgr/src/main/bin/filemgr
@@ -73,19 +73,19 @@ case "$1" in
         $JAVA_HOME/bin/java \
         	-cp ${LIB_DEPS} \
         	${DISTRIBUTED_CONF_PROPERTIES} \
-        	-Dlog4j.configurationFile=${FILEMGR_HOME}/etc/log4j2.xml \
-        	-Djava.util.logging.config.file=${FILEMGR_HOME}/etc/logging.properties \
+        	-Dlog4j.configurationFile="${FILEMGR_HOME}/etc/log4j2.xml" \
+        	-Djava.util.logging.config.file="${FILEMGR_HOME}/etc/logging.properties" \
     	    -Dorg.apache.oodt.cas.filemgr.properties=${CAS_FILEMGR_PROPS} \
         	org.apache.oodt.cas.filemgr.system.FileManagerServerMain \
         	--portNum $SERVER_PORT &
-        echo $! > ${RUN_HOME}/cas.filemgr.pid 
+        echo $! > "${RUN_HOME}/cas.filemgr.pid" 
         echo "OK"
         sleep 5
         ;;
   stop)
         echo -n "Shutting down cas file manager: "
-        kill `cat ${RUN_HOME}/cas.filemgr.pid`
-        rm -f ${RUN_HOME}/cas.filemgr.pid
+        kill `cat "${RUN_HOME}/cas.filemgr.pid"`
+        rm -f "${RUN_HOME}/cas.filemgr.pid"
         echo "OK"
         ;;
   restart)
@@ -93,8 +93,8 @@ case "$1" in
         $0 start
         ;;
   status)
-        if [ -e ${RUN_HOME}/cas.filemgr.pid ] ; then
-           pid=`cat ${RUN_HOME}/cas.filemgr.pid`
+        if [ -e "${RUN_HOME}/cas.filemgr.pid" ] ; then
+           pid=`cat "${RUN_HOME}/cas.filemgr.pid"`
            echo "cas filemgr is running with pid: $pid" 
         else
            echo "cas filemgr is not running"

--- a/filemgr/src/main/bin/filemgr
+++ b/filemgr/src/main/bin/filemgr
@@ -46,7 +46,7 @@ export PATH
 
 ## make sure that casfile manager has a run directory
 ## just to be on the safe side
-mkdir -p ${RUN_HOME}
+mkdir -p "${RUN_HOME}"
 
 for file in `find ../lib/*.jar`; do
      LIB_DEPS="${file}:${LIB_DEPS}"


### PR DESCRIPTION
This PR is a fix for issue https://issues.apache.org/jira/projects/OODT/issues/OODT-998.