### PR TITLE
[OODT-999] Fix for "File.toURL fails when their are spaces in project/repository paths"

### DIFF
--- a/commons/src/main/java/org/apache/oodt/commons/Configuration.java
+++ b/commons/src/main/java/org/apache/oodt/commons/Configuration.java
@@ -158,7 +158,7 @@ public class Configuration {
 					 return getEmptyConfiguration();
 				 }
 			 }
-			 url = file.toURL();
+			 url = file.toURI().toURL();
 		 }
 
 		 return getConfiguration(url);

--- a/commons/src/test/java/org/apache/oodt/commons/ConfigurationTest.java
+++ b/commons/src/test/java/org/apache/oodt/commons/ConfigurationTest.java
@@ -53,7 +53,7 @@ public class ConfigurationTest extends TestCase {
 
 	/** Test the various property methods. */
 	public void testConfiguration() throws IOException, SAXException {
-		Configuration c = new Configuration(tmpFile.toURL());
+		Configuration c = new Configuration(tmpFile.toURI().toURL());
 		Properties props = new Properties();
 		props.setProperty("globalKey1", "preset-value");
 		c.mergeProperties(props);

--- a/curator/services/src/main/java/org/apache/oodt/cas/curation/service/MetadataResource.java
+++ b/curator/services/src/main/java/org/apache/oodt/cas/curation/service/MetadataResource.java
@@ -662,7 +662,7 @@ public class MetadataResource extends CurationService {
       InstantiationException, RepositoryManagerException {
     String rootPolicyPath = this.cleanse(CurationService.config
         .getPolicyUploadPath());
-    String policyPath = new File(rootPolicyPath + policy).toURL()
+    String policyPath = new File(rootPolicyPath + policy).toURI().toURL()
         .toExternalForm();
     String[] policies = { policyPath };
     XMLRepositoryManager repMgr = new XMLRepositoryManager(Arrays
@@ -678,7 +678,7 @@ public class MetadataResource extends CurationService {
             CurationException {
         String rootPolicyPath = this.cleanse(CurationService.config
                 .getPolicyUploadPath());
-        String policyPath = new File(rootPolicyPath + policy).toURL()
+        String policyPath = new File(rootPolicyPath + policy).toURI().toURL()
                 .toExternalForm();
         String[] policies = {policyPath};
         XMLRepositoryManager repMgr = new XMLRepositoryManager(Arrays

--- a/curator/services/src/main/java/org/apache/oodt/cas/curation/service/PolicyResource.java
+++ b/curator/services/src/main/java/org/apache/oodt/cas/curation/service/PolicyResource.java
@@ -264,7 +264,7 @@ public class PolicyResource extends CurationService {
       RepositoryManagerException {
     String rootPolicyPath = this.cleanse(CurationService.config
         .getPolicyUploadPath());
-    String policyPath = new File(rootPolicyPath + policy).toURL()
+    String policyPath = new File(rootPolicyPath + policy).toURI().toURL()
         .toExternalForm();
     String[] policies = { policyPath };
     XMLRepositoryManager repMgr = new XMLRepositoryManager(Arrays

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/tools/ExpImpCatalog.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/tools/ExpImpCatalog.java
@@ -110,7 +110,7 @@ public class ExpImpCatalog {
         // first load the source prop file
         try {
             System.getProperties().load(
-                    new File(sPropFilePath).toURL().openStream());
+                    new File(sPropFilePath).toURI().toURL().openStream());
         } catch (Exception e) {
             throw new InstantiationException(e.getMessage());
         }
@@ -125,7 +125,7 @@ public class ExpImpCatalog {
         // first load the dest prop file
         try {
             System.getProperties().load(
-                    new File(dPropFilePath).toURL().openStream());
+                    new File(dPropFilePath).toURI().toURL().openStream());
         } catch (Exception e) {
             throw new InstantiationException(e.getMessage());
         }

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/validation/XMLValidationLayer.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/validation/XMLValidationLayer.java
@@ -469,7 +469,7 @@ public class XMLValidationLayer implements ValidationLayer {
         InputStream xmlInputStream;
 
         try {
-            xmlInputStream = new File(xmlFile).toURL().openStream();
+            xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
         } catch (IOException e) {
             LOG.log(Level.WARNING,
                     "IOException when getting input stream from [" + xmlFile

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/versioning/BasicVersioner.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/versioning/BasicVersioner.java
@@ -84,7 +84,7 @@ public class BasicVersioner implements Versioner {
             String dataStoreRef;
 
             try {
-                dataStoreRef = new File(new URI(productRepoPath)).toURL()
+                dataStoreRef = new File(new URI(productRepoPath)).toURI().toURL()
                         .toExternalForm();
                 if(!dataStoreRef.endsWith("/")){
                   dataStoreRef+="/";

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/versioning/DateTimeVersioner.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/versioning/DateTimeVersioner.java
@@ -109,7 +109,7 @@ public class DateTimeVersioner implements Versioner {
 
             try {
               dataStoreRef = new File(new URI(product.getProductType()
-                                                     .getProductRepositoryPath())).toURL()
+                                                     .getProductRepositoryPath())).toURI().toURL()
                                                                                   .toExternalForm()
                              + "/"
                              + product.getProductName()
@@ -154,7 +154,7 @@ public class DateTimeVersioner implements Versioner {
 
             try {
                 String dataStoreRef = new File(new URI(product.getProductType()
-                        .getProductRepositoryPath())).toURL().toExternalForm()
+                        .getProductRepositoryPath())).toURI().toURL().toExternalForm()
                         + URLEncoder.encode(product.getProductName(), "UTF-8")
                         + "/";
                 LOG.log(Level.INFO,

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/versioning/VersioningUtils.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/versioning/VersioningUtils.java
@@ -88,7 +88,7 @@ public final class VersioningUtils {
             if (!dir.equals(dirRoot)) {
                 try {
                     Reference r = new Reference();
-                    r.setOrigReference(dir.toURL().toExternalForm());
+                    r.setOrigReference(dir.toURI().toURL().toExternalForm());
                     r.setFileSize(dir.length());
                     references.add(r);
                 } catch (MalformedURLException e) {
@@ -106,7 +106,7 @@ public final class VersioningUtils {
                     // add the file references
                     try {
                         Reference r = new Reference();
-                        r.setOrigReference(file.toURL().toExternalForm());
+                        r.setOrigReference(file.toURI().toURL().toExternalForm());
                         r.setFileSize(file.length());
                         references.add(r);
                     } catch (MalformedURLException e) {
@@ -221,7 +221,7 @@ public final class VersioningUtils {
             String productRepoPathRef;
 
             try {
-                productRepoPathRef = new File(new URI(productRepoPath)).toURL()
+                productRepoPathRef = new File(new URI(productRepoPath)).toURI().toURL()
                                                                        .toExternalForm();
 
                 if (!productRepoPathRef.endsWith("/")) {

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/metadata/extractors/TestAbstractFilemgrMetExtractor.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/metadata/extractors/TestAbstractFilemgrMetExtractor.java
@@ -92,11 +92,11 @@ public class TestAbstractFilemgrMetExtractor extends TestCase {
                 "urn:oodt:GenericFile");
         String refUri = null;
         try {
-            refUri = new File(tmpDirFullPath).toURL().toExternalForm();
+            refUri = new File(tmpDirFullPath).toURI().toURL().toExternalForm();
             prod.setProductStructure(Product.STRUCTURE_HIERARCHICAL);
             prod.getProductType()
                     .setProductRepositoryPath(
-                            new File(tmpDirFullPath).getParentFile().toURL()
+                            new File(tmpDirFullPath).getParentFile().toURI().toURL()
                                     .toString());
         } catch (Exception e) {
             fail(e.getMessage());

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/structs/type/TestTypeHandler.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/structs/type/TestTypeHandler.java
@@ -234,7 +234,7 @@ public class TestTypeHandler extends TestCase {
         List<Reference> refs = new LinkedList<Reference>();
         URL refUrl = this.getClass().getResource("/ingest/test.txt");
         Reference ref = new Reference();
-        ref.setOrigReference(new File(refUrl.getFile()).toURL().toExternalForm());
+        ref.setOrigReference(new File(refUrl.getFile()).toURI().toURL().toExternalForm());
         ref.setFileSize(123);
         refs.add(ref);
         testProduct.setProductReferences(refs);

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/versioning/TestBasicVersioner.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/versioning/TestBasicVersioner.java
@@ -69,13 +69,13 @@ public class TestBasicVersioner extends TestCase {
 		p.setProductName("test_product");
 		p.setProductStructure(Product.STRUCTURE_FLAT);
 		ProductType type = new ProductType();
-		type.setProductRepositoryPath("file:///foo/bar");
+		type.setProductRepositoryPath("file:///foo/space%20bar");
 		p.setProductType(type);
 
 		List refs = new Vector();
 		try {
       URL url = this.getClass().getResource("/test.txt");
-      String refname = new File(url.getFile()).toURL().toExternalForm();
+      String refname = new File(url.getFile()).toURI().toURL().toExternalForm();
 			refs.add(refname);
 		} catch (MalformedURLException e) {
 			fail(e.getMessage());
@@ -94,16 +94,16 @@ public class TestBasicVersioner extends TestCase {
 		assertNotNull(generatedRef);
 
 		assertEquals("Versioned refs not equal: ref=[" + generatedRef + "]",
-				"file:/foo/bar/test_product/test.txt", generatedRef);
+				"file:/foo/space%20bar/test_product/test.txt", generatedRef);
 
 	}
 
   public void testVersionHierarchical() {
-    String expected = "file:/archive/testdir/";
+    String expected = "file:/space%20archive/testdir/";
     Product p = Product
         .getDefaultFlatProduct("testdir", "urn:oodt:GenericFile");
     p.setProductStructure(Product.STRUCTURE_HIERARCHICAL);
-    p.getProductType().setProductRepositoryPath("file:///archive");
+    p.getProductType().setProductRepositoryPath("file:///space%20archive");
 
     p.getProductReferences().add(
         new Reference("file:///tmp/somedir/", null, 4L));

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/versioning/TestDateTimeVersioner.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/versioning/TestDateTimeVersioner.java
@@ -72,7 +72,7 @@ public class TestDateTimeVersioner extends TestCase {
 		Product product = new Product();
 		ProductType type = new ProductType();
 
-		type.setProductRepositoryPath("file:///foo/bar");
+		type.setProductRepositoryPath("file:///foo/space%20bar");
 		product.setProductName("test_product");
 		product.setProductStructure(Product.STRUCTURE_FLAT);
 		product.setProductType(type);
@@ -88,7 +88,7 @@ public class TestDateTimeVersioner extends TestCase {
 		List refs = new Vector();
 		try {
       URL url = this.getClass().getResource("/test.txt");
-      String refname = new File(url.getFile()).toURL().toExternalForm();
+      String refname = new File(url.getFile()).toURI().toURL().toExternalForm();
 			refs.add(refname);
 		} catch (MalformedURLException e) {
 			fail(e.getMessage());
@@ -107,9 +107,9 @@ public class TestDateTimeVersioner extends TestCase {
 		assertNotNull(generatedRef);
 		assertEquals(
 				"Generated ref does not equal expected ref: generatedRef=["
-						+ generatedRef + "], expected=[file:/foo/bar/test_product" +
+						+ generatedRef + "], expected=[file:/foo/space%20bar/test_product" +
 								"/test.txt."+prodDateTimeNonIso+"]", 
-								"file:/foo/bar/test_product/test.txt."
+								"file:/foo/space%20bar/test_product/test.txt."
 						+ prodDateTimeNonIso, generatedRef);
 
 	}

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteConfigReader.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteConfigReader.java
@@ -46,7 +46,7 @@ public class CopyAndRewriteConfigReader implements MetExtractorConfigReader {
             throws MetExtractorConfigReaderException {
         try {
             CopyAndRewriteConfig config = new CopyAndRewriteConfig();
-            config.load(configFile.toURL().openStream());
+            config.load(configFile.toURI().toURL().openStream());
             return config;
         } catch (Exception e) {
             throw new MetExtractorConfigReaderException("Failed to parse '"

--- a/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteExtractor.java
+++ b/metadata/src/main/java/org/apache/oodt/cas/metadata/extractors/CopyAndRewriteExtractor.java
@@ -84,7 +84,7 @@ public class CopyAndRewriteExtractor extends CmdLineMetExtractor {
       try {
           met = new SerializableMetadata(new File(PathUtils
                   .replaceEnvVariables(((CopyAndRewriteConfig) this.config)
-                          .getProperty("orig.met.file.path"))).toURL()
+                          .getProperty("orig.met.file.path"))).toURI().toURL()
                   .openStream());
       } catch (Exception e) {
           LOG.log(Level.SEVERE, e.getMessage());

--- a/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEXMLFileUtils.java
+++ b/pcs/input/src/main/java/org/apache/oodt/pcs/input/PGEXMLFileUtils.java
@@ -338,7 +338,7 @@ public final class PGEXMLFileUtils {
     InputStream xmlInputStream;
 
     try {
-      xmlInputStream = new File(xmlFile).toURL().openStream();
+      xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
     } catch (IOException e) {
       LOG.log(Level.WARNING, "IOException when getting input stream from ["
           + xmlFile + "]: returning null document root");

--- a/pge/src/main/java/org/apache/oodt/cas/pge/PGETask.java
+++ b/pge/src/main/java/org/apache/oodt/cas/pge/PGETask.java
@@ -79,11 +79,11 @@ public class PGETask {
         }
 
         SerializableMetadata sm = new SerializableMetadata("UTF-8", false);
-        sm.loadMetadataFromXmlStream(new File(metadataFilePath).toURL()
+        sm.loadMetadataFromXmlStream(new File(metadataFilePath).toURI().toURL()
                 .openStream());
         WorkflowTaskConfiguration config = new WorkflowTaskConfiguration();
         config.getProperties().load(
-                new File(configPropertiesPath).toURL().openStream());
+                new File(configPropertiesPath).toURI().toURL().openStream());
 
         PGETask task = new PGETask(sm, config);
         task.run(pgeTaskInstanceClasspath);

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/instrepo/WorkflowInstanceMetadataReader.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/instrepo/WorkflowInstanceMetadataReader.java
@@ -119,7 +119,7 @@ public final class WorkflowInstanceMetadataReader implements
         InputStream xmlInputStream;
 
         try {
-            xmlInputStream = new File(xmlFile).toURL().openStream();
+            xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
         } catch (IOException e) {
             LOG.log(Level.WARNING,
                     "IOException when getting input stream from [" + xmlFile

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/lifecycle/WorkflowLifecyclesReader.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/lifecycle/WorkflowLifecyclesReader.java
@@ -168,7 +168,7 @@ public final class WorkflowLifecyclesReader implements WorkflowLifecycleMetKeys 
         InputStream xmlInputStream;
 
         try {
-            xmlInputStream = new File(xmlFile).toURL().openStream();
+            xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
         } catch (IOException e) {
             LOG.log(Level.WARNING,
                     "IOException when getting input stream from [" + xmlFile

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/policy/TaskPolicyReader.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/policy/TaskPolicyReader.java
@@ -186,7 +186,7 @@ public final class TaskPolicyReader {
         InputStream xmlInputStream = null;
 
         try {
-            xmlInputStream = new File(xmlFile).toURL().openStream();
+            xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
         } catch (IOException e) {
             LOG.log(Level.WARNING,
                     "IOException when getting input stream from [" + xmlFile

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/repository/XMLWorkflowRepository.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/repository/XMLWorkflowRepository.java
@@ -670,7 +670,7 @@ public class XMLWorkflowRepository implements WorkflowRepository {
         InputStream xmlInputStream;
 
         try {
-            xmlInputStream = new File(xmlFile).toURL().openStream();
+            xmlInputStream = new File(xmlFile).toURI().toURL().openStream();
         } catch (IOException e) {
             LOG.log(Level.WARNING,
                     "IOException when getting input stream from [" + xmlFile


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/projects/OODT/issues/OODT-999
1) Modified unit tests involving data repository path to expose the issue.
2) Replaced the deprecated method File.toURL() which causes the issue by File.toURI().toURL().
