### PR TITLE
Fix catalina Issues with mvn command

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER Tom Barber
 #Setting the Work Directory for OODT in Docker Container
 WORKDIR /usr/src
 
-#RUN curl -o radix https://raw.githubusercontent.com/apache/oodt/trunk/mvn/archetypes/radix/src/main/resources/bin/radix | bash
 RUN mvn archetype:generate -DarchetypeGroupId=org.apache.oodt -DarchetypeArtifactId=radix-archetype -DarchetypeVersion=0.9 -Doodt=1.2.3 -DgroupId=com.mycompany -DartifactId=oodt -Dversion=0.1 && mv oodt oodt-src; cd oodt-src; mvn package && mkdir /usr/src/oodt; tar -xvf /usr/src/oodt-src/distribution/target/oodt-distribution-0.1-bin.tar.gz -C /usr/src/oodt && cd /usr/src/oodt-src && mvn clean && rm -rf ~/.m2
 # Maven archetype generation command to make an oodt project.
 # Fix Below Parameters before build the docker image

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,12 +1,30 @@
 FROM maven:3.5
 MAINTAINER Tom Barber
 
-#ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
-
+#Setting the Work Directory for OODT in Docker Container
 WORKDIR /usr/src
 
+#RUN curl -o radix https://raw.githubusercontent.com/apache/oodt/trunk/mvn/archetypes/radix/src/main/resources/bin/radix | bash
 RUN mvn archetype:generate -DarchetypeGroupId=org.apache.oodt -DarchetypeArtifactId=radix-archetype -DarchetypeVersion=0.9 -Doodt=1.2.3 -DgroupId=com.mycompany -DartifactId=oodt -Dversion=0.1 && mv oodt oodt-src; cd oodt-src; mvn package && mkdir /usr/src/oodt; tar -xvf /usr/src/oodt-src/distribution/target/oodt-distribution-0.1-bin.tar.gz -C /usr/src/oodt && cd /usr/src/oodt-src && mvn clean && rm -rf ~/.m2
+# Maven archetype generation command to make an oodt project.
+# Fix Below Parameters before build the docker image
+# groupId = specify your company's namespace
+# artifactId = pecify a short name of your project
+# version = initial version label for your project
+# oodt = the version of OODT that you want your project to be built on
+RUN mvn archetype:generate -DarchetypeGroupId=org.apache.oodt \
+    -DarchetypeArtifactId=radix-archetype -DarchetypeVersion=0.9 \
+    -Doodt=1.2.5 -DgroupId=com.mycompany \
+    -DartifactId=oodt -Dversion=0.1 \
+    && mv oodt oodt-src; \
+    cd oodt-src; \
+    mvn package \
+    && mkdir /usr/src/oodt; \
+    tar -xvf distribution/target/oodt-distribution-0.1-bin.tar.gz -C /usr/src/oodt \
+    && mkdir /usr/src/oodt/tomcat/server/webapps/host-manager /usr/src/oodt/tomcat/server/webapps/manager \
+    && mvn clean && rm -rf ~/.m2
 
+#Exposing required ports to local
 EXPOSE 8080
 EXPOSE 9000
 EXPOSE 2001
@@ -14,4 +32,5 @@ EXPOSE 9001
 EXPOSE 9200
 EXPOSE 9002
 
+# Starting OODT and Loging catalina log
 CMD cd /usr/src/oodt/bin/ && ./oodt start && tail -f /usr/src/oodt/tomcat/logs/catalina.out

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -32,7 +32,7 @@ sudo docker build -t oodt_docker .
 ### Running OODT Docker Image
 After your docker image successfully built, execute below prompt command.`oodt_docker` is the oodt docker image name.
 ```dockerfile
-sudo docker run -p 8080:8080 -name my_first_oodt -i -t oodt_docker
+sudo docker run -p 8080:8080 -p 9000:9000 -p 9001:9001 -p 9002:9002 -p 2001:2001 -p 9200:9200  --name my_first_oodt -i -t oodt_docker
 ```
 The -p command forwards 8080 to localhost so you can login to opsui by visiting http://localhost:8080/opsui
 

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,10 +1,10 @@
-# OODT-docker
+# OODT Docker
 
-Automatic RADIX build for Apache OODT
+Automated RADIX build on Docker for Apache OODT
 
 ## Usage
 
-You should edit docker file replacing the parameters below with whatever you want before build the image.
+You should edit docker file replacing the parameters below with values you desire before building this image.
 
 1. The groupId is a place to specify your company's namespace. 
     ```dockerfile
@@ -24,7 +24,7 @@ You should edit docker file replacing the parameters below with whatever you wan
     ```
 
 ### Building OODT Docker Image
-Execute below command in a prompt which is opened where the Docker file placed. Replace any thing with `oodt_docker` as it is the name of your docker image.
+Execute below command in a prompt which is opened where the Docker file placed. Replace  `oodt_docker` with any name as it will be the name of your docker image.
 ```dockerfile
 sudo docker build -t oodt_docker . 
 ```    

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -34,6 +34,3 @@ After your docker image successfully built, execute below prompt command.`oodt_d
 ```dockerfile
 sudo docker run -p 8080:8080 -p 9000:9000 -p 9001:9001 -p 9002:9002 -p 2001:2001 -p 9200:9200  --name my_first_oodt -i -t oodt_docker
 ```
-The -p command forwards 8080 to localhost so you can login to opsui by visiting http://localhost:8080/opsui
-
-If you want access to the other services on the system you will also have to forward those ports locally.

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,4 +1,3 @@
-# oodt-docker
 # OODT-docker
 
 Automatic RADIX build for Apache OODT

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,0 +1,40 @@
+# oodt-docker
+# OODT-docker
+
+Automatic RADIX build for Apache OODT
+
+## Usage
+
+You should edit docker file replacing the parameters below with whatever you want before build the image.
+
+1. The groupId is a place to specify your company's namespace. 
+    ```dockerfile
+    -DgroupId = com.mycompany
+    ```
+2. The artifactId is a place to specify a short name of your project. 
+    ```dockerfile
+    -DartifactId = oodt
+    ```
+3. The version indicates the initial version label for your project. 
+    ```dockerfile
+    -Dversion = 0.1
+    ``` 
+4. The oodt flag indicates the version of OODT that you want your project to be built on. N.B., this should most likely match [the most recent version of OODT](https://search.maven.org/search?q=g:org.apache.oodt).
+    ```dockerfile
+    -Doodt = 1.2.5
+    ```
+
+### Building OODT Docker Image
+Execute below command in a prompt which is opened where the Docker file placed. Replace any thing with `oodt_docker` as it is the name of your docker image.
+```dockerfile
+sudo docker build -t oodt_docker . 
+```    
+
+### Running OODT Docker Image
+After your docker image successfully built, execute below prompt command.`oodt_docker` is the oodt docker image name.
+```dockerfile
+sudo docker run -p 8080:8080 -name my_first_oodt -i -t oodt_docker
+```
+The -p command forwards 8080 to localhost so you can login to opsui by visiting http://localhost:8080/opsui
+
+If you want access to the other services on the system you will also have to forward those ports locally.


### PR DESCRIPTION
When running OODT-Docker image, it generates below error which can be found in the Catalina.out file.

`
java.lang.IllegalArgumentException: Document base /usr/src/oodt/tomcat/server/webapps/manager does not exist or is not a readable directory`

This PR will fix above Issue.