### PR TITLE
[OODT-1009] Replace CORBA dependencies with reflection

### DIFF
--- a/commons/src/main/java/org/apache/oodt/commons/AvroExecServer.java
+++ b/commons/src/main/java/org/apache/oodt/commons/AvroExecServer.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.rmi.server.RemoteObject;
@@ -229,9 +230,14 @@ public class AvroExecServer {
                     objOut.flush();
                     System.out.println();
                 } else {
-                    org.omg.PortableServer.Servant servant=(org.omg.PortableServer.Servant)server.getServant();
-                    org.omg.CORBA.ORB orb = servant._orb();
-                    System.out.println(orb.object_to_string(servant._this_object(orb)));
+                    Class<?> servantClass = Class.forName("org.omg.PortableServer.Servant");
+                    Class<?> orbClass = Class.forName("org.omg.CORBA.ORB");
+                    Class<?> corbaObjectClass = Class.forName("org.omg.CORBA.Object");
+
+                    Object servant = servantClass.cast(server.getServant());
+                    Object orb = orbClass.cast(servantClass.getDeclaredMethod("_orb").invoke(servant));
+                    Object object = corbaObjectClass.cast(servantClass.getDeclaredMethod("_this_object", orbClass).invoke(servant, orb));
+                    System.out.println(orbClass.getDeclaredMethod("object_to_string", corbaObjectClass).invoke(orb, object));
                 }
                 System.out.flush();
             }
@@ -332,13 +338,18 @@ public class AvroExecServer {
         } catch (NamingException ignore) {}
 
         // Kill the ORB.  YEAH!  KILL IT, KILL IT, KIIIIIIIIIIIIIIL IIIIIIIIT!!!!!!!1
+        // Replace org.omg dependent code with reflection (to make it compatible with Java 11 (LTS))
         try {
-            if (servant instanceof org.omg.PortableServer.Servant) {
-                org.omg.PortableServer.Servant s = (org.omg.PortableServer.Servant) servant;
-                org.omg.CORBA.ORB orb = s._orb();
-                orb.shutdown(false/*=>terminate without waiting for reqs to complete*/);
+            Class<?> servantClass = Class.forName("org.omg.PortableServer.Servant");
+            Class<?> orbClass = Class.forName("org.omg.CORBA.ORB");
+            if (servantClass.isInstance(servant)) {
+                Object s = servantClass.cast(servant);
+                Object orb = orbClass.cast(servantClass.getDeclaredMethod("_orb").invoke(s));
+                orbClass.getDeclaredMethod("shutdown", boolean.class)
+                        .invoke(orb, false/*=>terminate without waiting for reqs to complete*/);
             }
-        } catch (Throwable ignore) {}
+        } catch (Exception ignore) {
+        }
     }
 
     /** Get my name.


### PR DESCRIPTION
I removed the compile-time dependencies to CORBA package in ```oodt-commons``` module, and replaced them with reflection-based dependency resolving. 

All test cases passed after the change was made on JDK 10