### PR TITLE
[OODT-1013] Update Beta Versions of Maven Assembly Plugin in OODT Radix Builds

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -81,7 +81,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-2</version>
+                <version>2.6</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -182,7 +182,7 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -326,7 +326,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/crawler/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/extensions/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/extensions/pom.xml
@@ -36,7 +36,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/filemgr/pom.xml
@@ -40,7 +40,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-assembly-plugin</artifactId>
-                  <version>2.2-beta-2</version>
+                  <version>2.6</version>
                   <configuration>
                      <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
@@ -67,7 +67,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-assembly-plugin</artifactId>
-                  <version>2.2-beta-2</version>
+                  <version>2.6</version>
                   <configuration>
                      <descriptors>
                         <descriptor>src/main/assembly/assembly.fm-solr-catalog.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/pcs/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/pge/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/pge/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/resmgr/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/solr/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/solr/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/pom.xml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/workflow/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/pcs/core/pom.xml
+++ b/pcs/core/pom.xml
@@ -93,7 +93,7 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -117,7 +117,7 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/resource/pom.xml
+++ b/resource/pom.xml
@@ -120,7 +120,7 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -253,7 +253,7 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>2.6</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>


### PR DESCRIPTION
Hello,

I've updated the maven-assembly-plugin from 2.2-beta to 2.6 version. I noticed that when using 2.2-beta version, the tar -xvf command warns of lone blocks in the tar.gz files. However, after updating them to stable releases, this warning is not issued.