### PR TITLE
[OODT-1017] ResourceManagerUtils uses XmlRpcResourceManagerClient by default

### DIFF
--- a/pcs/core/src/main/java/org/apache/oodt/pcs/util/ResourceManagerUtils.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/util/ResourceManagerUtils.java
@@ -25,20 +25,21 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 //OODT imports
-import org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient;
+import org.apache.oodt.cas.resource.system.ResourceManagerClient;
+import org.apache.oodt.cas.resource.system.rpc.ResourceManagerFactory;
 
 /**
  * A set of utility methods that can be used by PCS that need to
  * communicate with the Resource Manager.
- * 
+ *
  * @author mattmann
  * @version $Revision$
- * 
+ *
  */
 public class ResourceManagerUtils {
 
   /* our resource manager client */
-  private XmlRpcResourceManagerClient client;
+  private ResourceManagerClient client;
 
   /* our log stream */
   private static final Logger LOG = Logger.getLogger(ResourceManagerUtils.class
@@ -51,19 +52,19 @@ public class ResourceManagerUtils {
   }
 
   public ResourceManagerUtils(URL url) {
-    this.client = new XmlRpcResourceManagerClient(url);
+    this.client = ResourceManagerFactory.getResourceManagerClient(url);
     this.rmUrl = url;
 
   }
 
-  public ResourceManagerUtils(XmlRpcResourceManagerClient client) {
+  public ResourceManagerUtils(ResourceManagerClient client) {
     this.client = client;
   }
 
   /**
    * @return the client
    */
-  public XmlRpcResourceManagerClient getClient() {
+  public ResourceManagerClient getClient() {
     return client;
   }
 
@@ -71,7 +72,7 @@ public class ResourceManagerUtils {
    * @param client
    *          the client to set
    */
-  public void setClient(XmlRpcResourceManagerClient client) {
+  public void setClient(ResourceManagerClient client) {
     this.client = client;
     if (this.client != null) {
       this.rmUrl = this.client.getResMgrUrl();
@@ -90,7 +91,7 @@ public class ResourceManagerUtils {
   }
 
   /**
-   * 
+   *
    * @return The {@link URL} for the Resource Manager that this
    *         ResourceManagerUtils communicates with.
    */

--- a/resource/src/main/java/org/apache/oodt/cas/resource/cli/action/ResourceCliAction.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/cli/action/ResourceCliAction.java
@@ -47,11 +47,7 @@ public abstract class ResourceCliAction extends CmdLineAction {
         if (client != null) {
             return client;
         } else {
-            try {
-                return ResourceManagerFactory.getResourceManagerClient(new URL(getUrl()));
-            } catch (Exception e) {
-                throw new IllegalStateException("Unable to create client", e);
-            }
+            return ResourceManagerFactory.getResourceManagerClient(new URL(getUrl()));
         }
     }
 

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
@@ -46,7 +46,7 @@ public class AvroRpcResourceManagerClient implements ResourceManagerClient {
 
     /* our log stream */
     private static Logger LOG = Logger
-            .getLogger(XmlRpcResourceManagerClient.class.getName());
+            .getLogger(AvroRpcResourceManagerClient.class.getName());
 
     /* resource manager url */
     private URL resMgrUrl = null;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/rpc/ResourceManagerFactory.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/rpc/ResourceManagerFactory.java
@@ -64,7 +64,7 @@ public class ResourceManagerFactory {
         return manager;
     }
 
-    public static ResourceManagerClient getResourceManagerClient(URL url) throws Exception {
+    public static ResourceManagerClient getResourceManagerClient(URL url) throws IllegalStateException {
         loadProperties();
         String resMgrClientClass = System.getProperty("resmgr.manager.client",
                 "org.apache.oodt.cas.resource.system.AvroRpcResourceManagerClient");
@@ -77,7 +77,7 @@ public class ResourceManagerFactory {
             client = (ResourceManagerClient) constructor.newInstance(url);
         } catch (Exception e) {
             logger.error("Unable to create resource manager", e);
-            throw e;
+            throw new IllegalStateException("Unable to create client", e);
         }
 
         return client;


### PR DESCRIPTION
The class {{pcs/core/src/main/java/org/apache/oodt/pcs/util/ResourceManagerUtils.java}} instantiates a {{XmlRpcResourceManagerClient}} by default. This causes OPSUI to attempt to connect using XmlRpc though ResMgr runs using AvroRpc.

I've updated the ResourceManagerUtils class to use the ResourceManagerClientFactory class for instantiating a ResourceManagerClient.