### PR TITLE
[OODT-1018] OPSUI throwing NotSerializableException on several classes

### DIFF
--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ExtractorSpec.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ExtractorSpec.java
@@ -18,6 +18,7 @@
 package org.apache.oodt.cas.filemgr.structs;
 
 //JDK imports
+import java.io.Serializable;
 import java.util.Properties;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Properties;
  * a {@link FilemgrMetExtractor}.
  * </p>.
  */
-public class ExtractorSpec {
+public class ExtractorSpec implements Serializable {
 
     private String className;
 

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductPage.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductPage.java
@@ -17,6 +17,7 @@
 
 package org.apache.oodt.cas.filemgr.structs;
 
+import java.io.Serializable;
 import java.util.Collections;
 //JDK imports
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.Vector;
  * </p>
  * 
  */
-public class ProductPage {
+public class ProductPage implements Serializable {
 
     /* the number of this page */
     private int pageNum = -1;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductType.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/ProductType.java
@@ -17,6 +17,7 @@
 
 package org.apache.oodt.cas.filemgr.structs;
 
+import java.io.Serializable;
 import java.util.Collections;
 //JDK imports
 import java.util.List;
@@ -39,7 +40,7 @@ import org.apache.oodt.cas.metadata.Metadata;
  * </p>
  * 
  */
-public class ProductType {
+public class ProductType implements Serializable {
 
     /* the unique ID representing this product type */
     private String productTypeId = null;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/Reference.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/structs/Reference.java
@@ -29,6 +29,7 @@ import org.apache.tika.mime.MimeTypesFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,7 +46,7 @@ import java.util.logging.Logger;
  * </p>
  * 
  */
-public class Reference {
+public class Reference implements Serializable {
     private static Logger LOG = Logger.getLogger(Reference.class.getName());
     /* the item's original location */
     private String origReference = null;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/FileManagerClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/FileManagerClient.java
@@ -37,6 +37,7 @@ import org.apache.oodt.cas.metadata.Metadata;
 //JDK imports
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URL;
 import java.util.List;
 
@@ -47,7 +48,7 @@ import java.util.List;
  * <p>Interface of client for FileManager RPC logic. All methods that are used for
  * RPC transfer.</p>
  */
-public interface FileManagerClient extends Closeable {
+public interface FileManagerClient extends Closeable, Serializable {
 
     public boolean refreshConfigAndPolicy();
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlInfo.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.oodt.pcs.health;
 
+import java.io.Serializable;
+
 /**
  * Information about a crawler: its <code>crawlerName</code> and
  * <code>crawlerPort</code>.
@@ -24,7 +26,7 @@ package org.apache.oodt.pcs.health;
  * @author mattmann
  * @version $Revision$
  */
-public class CrawlInfo {
+public class CrawlInfo implements Serializable {
 
   private String crawlerName;
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlerHealth.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlerHealth.java
@@ -18,6 +18,8 @@
 package org.apache.oodt.pcs.health;
 
 
+import java.io.Serializable;
+
 /**
  * 
  * Health of a PCS Crawler in terms of the number of crawls performed, and
@@ -27,7 +29,7 @@ package org.apache.oodt.pcs.health;
  * @version $Revision$
  * 
  */
-public class CrawlerHealth {
+public class CrawlerHealth implements Serializable {
 
   private String crawlerName;
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlerPropertiesMetKeys.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlerPropertiesMetKeys.java
@@ -17,6 +17,8 @@
 
 package org.apache.oodt.pcs.health;
 
+import java.io.Serializable;
+
 /**
  * 
  * Met keys read from the {@link CrawlPropertiesFile}.
@@ -24,7 +26,7 @@ package org.apache.oodt.pcs.health;
  * @author mattmann
  * @version $Revision$
  */
-public interface CrawlerPropertiesMetKeys {
+public interface CrawlerPropertiesMetKeys extends Serializable {
 
   String CRAWLER_INFO_GROUP = "CrawlerInfo";
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlerStatus.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/CrawlerStatus.java
@@ -17,13 +17,15 @@
 
 package org.apache.oodt.pcs.health;
 
+import java.io.Serializable;
+
 /**
  * Provides status about a Crawler to the {@link PCSHealthMonitor}.
  * 
  * @author mattmann
  * @version $Revision$
  */
-public class CrawlerStatus {
+public class CrawlerStatus implements Serializable {
 
     private CrawlInfo info;
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/JobHealthStatus.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/JobHealthStatus.java
@@ -18,6 +18,8 @@
 package org.apache.oodt.pcs.health;
 
 
+import java.io.Serializable;
+
 /**
  * 
  * A container representing Job health status in the PCS
@@ -25,7 +27,7 @@ package org.apache.oodt.pcs.health;
  * @author mattmann
  * @version $Revision$
  */
-public class JobHealthStatus {
+public class JobHealthStatus implements Serializable {
 
   private String status;
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/PCSDaemonStatus.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/PCSDaemonStatus.java
@@ -16,6 +16,8 @@
  */
 package org.apache.oodt.pcs.health;
 
+import java.io.Serializable;
+
 /**
  * @author mattmann
  * @version $Revision$
@@ -25,7 +27,7 @@ package org.apache.oodt.pcs.health;
  * File Manager, the Workflow Manager, or the Resource Manager)
  * </p>.
  */
-public class PCSDaemonStatus {
+public class PCSDaemonStatus implements Serializable {
 
     private String daemonName;
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/PCSHealthMonitorMetKeys.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/PCSHealthMonitorMetKeys.java
@@ -17,13 +17,15 @@
 
 package org.apache.oodt.pcs.health;
 
+import java.io.Serializable;
+
 /**
  * Met keys for the {@link PCSHealthMonitor} tool
  * 
  * @author mattmann
  * @version $Revision$
  */
-public interface PCSHealthMonitorMetKeys {
+public interface PCSHealthMonitorMetKeys extends Serializable {
 
   String HEADER_AND_FOOTER = "--------------------------------------";
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/PCSHealthMonitorReport.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/PCSHealthMonitorReport.java
@@ -21,6 +21,7 @@ package org.apache.oodt.pcs.health;
 import org.apache.oodt.commons.date.DateUtils;
 
 //JDK imports
+import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -33,7 +34,7 @@ import java.util.List;
  * @author mattmann
  * @version $Revision$
  */
-public class PCSHealthMonitorReport {
+public class PCSHealthMonitorReport implements Serializable {
 
   private Date generationDate;
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/health/WorkflowStatesMetKeys.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/health/WorkflowStatesMetKeys.java
@@ -17,6 +17,8 @@
 
 package org.apache.oodt.pcs.health;
 
+import java.io.Serializable;
+
 /**
  * 
  * Met keys for the {@link WorkflowStatesFile}
@@ -24,7 +26,7 @@ package org.apache.oodt.pcs.health;
  * @author mattmann
  * @version $Revision$
  */
-public interface WorkflowStatesMetKeys {
+public interface WorkflowStatesMetKeys extends Serializable {
 
   String WORKFLOW_STATES_GROUP = "WorkflowStatesGroup";
 

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/util/FileManagerUtils.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/util/FileManagerUtils.java
@@ -36,6 +36,7 @@ import org.apache.oodt.cas.metadata.Metadata;
 
 //JDK imports
 import java.io.File;
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -55,7 +56,7 @@ import java.util.logging.Logger;
  * @version $Revision$
  * 
  */
-public class FileManagerUtils implements PCSConfigMetadata {
+public class FileManagerUtils implements PCSConfigMetadata, Serializable {
   /* our log stream */
   private static Logger LOG = Logger
       .getLogger(FileManagerUtils.class.getName());

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/util/ResourceManagerUtils.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/util/ResourceManagerUtils.java
@@ -18,6 +18,7 @@
 package org.apache.oodt.pcs.util;
 
 //JDK imports
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -35,7 +36,7 @@ import org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient;
  * @version $Revision$
  * 
  */
-public class ResourceManagerUtils {
+public class ResourceManagerUtils implements Serializable {
 
   /* our resource manager client */
   private XmlRpcResourceManagerClient client;

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/util/WorkflowManagerUtils.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/util/WorkflowManagerUtils.java
@@ -22,6 +22,7 @@ import org.apache.oodt.cas.workflow.system.WorkflowManagerClient;
 import org.apache.oodt.cas.workflow.system.rpc.RpcCommunicationFactory;
 import org.apache.xmlrpc.XmlRpcClient;
 
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -38,7 +39,7 @@ import java.util.logging.Logger;
  * @author mattmann
  * @version $Revision$
  */
-public class WorkflowManagerUtils {
+public class WorkflowManagerUtils implements Serializable {
 
   /* our workflow manager client */
   private WorkflowManagerClient client;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/ResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/ResourceManagerClient.java
@@ -26,10 +26,11 @@ import org.apache.oodt.cas.resource.structs.exceptions.JobRepositoryException;
 import org.apache.oodt.cas.resource.structs.exceptions.MonitorException;
 import org.apache.oodt.cas.resource.structs.exceptions.QueueManagerException;
 
+import java.io.Serializable;
 import java.net.URL;
 import java.util.List;
 
-public interface ResourceManagerClient {
+public interface ResourceManagerClient extends Serializable {
 
     boolean isJobComplete(String jobId) throws JobRepositoryException;
 

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/structs/WorkflowInstancePage.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/structs/WorkflowInstancePage.java
@@ -19,6 +19,7 @@
 package org.apache.oodt.cas.workflow.structs;
 
 //JDK imports
+import java.io.Serializable;
 import java.util.List;
 import java.util.Vector;
 
@@ -30,7 +31,7 @@ import java.util.Vector;
  * Describe your class here
  * </p>.
  */
-public class WorkflowInstancePage {
+public class WorkflowInstancePage implements Serializable {
 
     /* the number of this page */
     private int pageNum = -1;

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/WorkflowManagerClient.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/WorkflowManagerClient.java
@@ -25,6 +25,7 @@ import org.apache.oodt.cas.workflow.structs.WorkflowTask;
 import org.apache.oodt.cas.workflow.structs.WorkflowCondition;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.net.URL;
 import java.util.List;
 import java.util.Vector;
@@ -37,7 +38,7 @@ import java.util.Vector;
  * Base interface for client RPC implementation.
  * </p>
  */
-public interface WorkflowManagerClient extends Closeable {
+public interface WorkflowManagerClient extends Closeable, Serializable {
 
     boolean refreshRepository()
             throws Exception;


### PR DESCRIPTION
OPSUI attempts to serialize classes that have not implemented the Serializable interface. This pollutes the logs with a large number of NotSerializableException stack traces.

I've implemented the Serializable interface for several classes which throw NotSerializableException as seen in the logs, which significantly reduced the log clutter on OPSUI.