### PR TITLE
[OODT-1020] ResmgrClient, WmgrClient and BatchMgrProxy try to connect to localhost by default

### DIFF
--- a/pcs/core/src/main/java/org/apache/oodt/pcs/tools/PCSHealthMonitor.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/tools/PCSHealthMonitor.java
@@ -620,7 +620,7 @@ public final class PCSHealthMonitor implements CoreMetKeys,
     NettyTransceiver client;
     AvroRpcBatchStub proxy;
     try {
-      client = new NettyTransceiver(new InetSocketAddress(node.getIpAddr().getPort()));
+      client = new NettyTransceiver(new InetSocketAddress(node.getIpAddr().getHost(), node.getIpAddr().getPort()));
       proxy = (AvroRpcBatchStub) SpecificRequestor.getClient(AvroRpcBatchStub.class, client);
       return proxy.isAlive();
     } catch (IOException e) {

--- a/resource/src/main/java/org/apache/oodt/cas/resource/batchmgr/AvroRpcBatchMgrProxy.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/batchmgr/AvroRpcBatchMgrProxy.java
@@ -57,7 +57,7 @@ public class AvroRpcBatchMgrProxy extends Thread implements Runnable {
     public boolean nodeAlive() {
 
         try {
-            this.client = new NettyTransceiver(new InetSocketAddress(remoteHost.getIpAddr().getPort()));
+            this.client = new NettyTransceiver(new InetSocketAddress(remoteHost.getIpAddr().getHost(), remoteHost.getIpAddr().getPort()));
             this.proxy = (AvroRpcBatchStub) SpecificRequestor.getClient(AvroRpcBatchStub.class, client);
         } catch (IOException e) {
             e.printStackTrace();
@@ -80,7 +80,7 @@ public class AvroRpcBatchMgrProxy extends Thread implements Runnable {
     public boolean killJob() {
 
         try {
-            this.client = new NettyTransceiver(new InetSocketAddress(remoteHost.getIpAddr().getPort()));
+            this.client = new NettyTransceiver(new InetSocketAddress(remoteHost.getIpAddr().getHost(), remoteHost.getIpAddr().getPort()));
             this.proxy = (AvroRpcBatchStub) SpecificRequestor.getClient(AvroRpcBatchStub.class, client);
         } catch (IOException e) {
             LOG.log(Level.SEVERE, "Failed connection with the server.", e);
@@ -104,7 +104,7 @@ public class AvroRpcBatchMgrProxy extends Thread implements Runnable {
 
     public void run() {
         try {
-            this.client = new NettyTransceiver(new InetSocketAddress(remoteHost.getIpAddr().getPort()));
+            this.client = new NettyTransceiver(new InetSocketAddress(remoteHost.getIpAddr().getHost(), remoteHost.getIpAddr().getPort()));
             this.proxy = (AvroRpcBatchStub) SpecificRequestor.getClient(AvroRpcBatchStub.class, client);
         } catch (IOException e) {
             LOG.log(Level.SEVERE, "Failed connection with the server.", e);

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
@@ -466,7 +466,7 @@ public class AvroRpcResourceManager implements org.apache.oodt.cas.resource.stru
         try {
             this.scheduler.getMonitor().getNodeById(nodeId).setCapacity(capacity);
         } catch (MonitorException e) {
-            logger.warn("Exception setting capacity on node {}: ", nodeId, e.getMessage());
+            logger.warn("Exception setting capacity on node {}: {}", nodeId, e.getMessage());
             return false;
         }
         return true;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
@@ -73,7 +73,7 @@ public class AvroRpcResourceManagerClient implements ResourceManagerClient {
         }
 
         try {
-            this.client = new NettyTransceiver(new InetSocketAddress(url.getPort()));
+            this.client = new NettyTransceiver(new InetSocketAddress(url.getHost(), url.getPort()));
             proxy = (ResourceManager) SpecificRequestor.getClient(ResourceManager.class, client);
         } catch (IOException e) {
             e.printStackTrace();

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManagerClient.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManagerClient.java
@@ -240,7 +240,7 @@ public class AvroRpcWorkflowManagerClient implements WorkflowManagerClient {
     public void setWorkflowManagerUrl(URL workflowManagerUrl) {
         this.workflowManagerUrl = workflowManagerUrl;
         try {
-            client = new NettyTransceiver(new InetSocketAddress(workflowManagerUrl.getPort()));
+            client = new NettyTransceiver(new InetSocketAddress(workflowManagerUrl.getHost(), workflowManagerUrl.getPort()));
             proxy = SpecificRequestor.getClient(org.apache.oodt.cas.workflow.struct.avrotypes.WorkflowManager.class, client);
         } catch (IOException e) {
             logger.error("Error occurred when setting workflow manager url: {}", workflowManagerUrl, e);


### PR DESCRIPTION
When OPSUI attempts to use resmgr client and wmgr client, the connection fails when the servers are not running on localhost, but on a different hostname (e.g., in docker containers).

As a resolution to this, I added the hostname in addition to the port for all instances of InetSocketAddress() in the clients.