### PR TITLE
[OODT-1018] OPSUI throwing NotSerializableException on several classes

### DIFF
--- a/curator/sso/src/main/java/org/apache/oodt/security/sso/OpenSSOImpl.java
+++ b/curator/sso/src/main/java/org/apache/oodt/security/sso/OpenSSOImpl.java
@@ -44,7 +44,7 @@ public class OpenSSOImpl extends AbstractWebBasedSingleSignOn implements
   private static final Logger LOG = Logger.getLogger(OpenSSOImpl.class
       .getName());
 
-  private SSOProxy ssoProxy;
+  private transient SSOProxy ssoProxy;
 
   /**
    * Default constructor.

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/AvroFileManagerClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/AvroFileManagerClient.java
@@ -68,10 +68,10 @@ public class AvroFileManagerClient implements FileManagerClient {
     private static final Logger logger = LoggerFactory.getLogger(AvroFileManagerClient.class);
 
     /** Avro-Rpc client */
-    private Transceiver client;
+    private transient Transceiver client;
 
     /** proxy for the server */
-    private AvroFileManager proxy;
+    private transient AvroFileManager proxy;
 
     /* URL where the fileManager is */
     private URL fileManagerUrl;

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManagerClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/XmlRpcFileManagerClient.java
@@ -77,7 +77,7 @@ import java.util.logging.Logger;
 public class XmlRpcFileManagerClient implements FileManagerClient {
 
   /* our xml rpc client */
-  private XmlRpcClient client = null;
+  private transient XmlRpcClient client = null;
 
   /* our log stream */
   private static Logger LOG = Logger.getLogger(XmlRpcFileManagerClient.class

--- a/resource/src/main/java/org/apache/oodt/cas/resource/batchmgr/AvroRpcBatchMgrProxy.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/batchmgr/AvroRpcBatchMgrProxy.java
@@ -41,9 +41,9 @@ public class AvroRpcBatchMgrProxy extends Thread implements Runnable {
 
     private ResourceNode remoteHost;
 
-    private Transceiver client;
+    private transient Transceiver client;
 
-    private AvroRpcBatchStub proxy;
+    private transient AvroRpcBatchStub proxy;
 
     private AvroRpcBatchMgr parent;
 

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
@@ -51,8 +51,8 @@ public class AvroRpcResourceManagerClient implements ResourceManagerClient {
     /* resource manager url */
     private URL resMgrUrl = null;
 
-    Transceiver client;
-    ResourceManager proxy;
+    transient Transceiver client;
+    transient ResourceManager proxy;
 
     public AvroRpcResourceManagerClient(URL url) {
         // set up the configuration, if there is any

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManagerClient.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManagerClient.java
@@ -47,8 +47,8 @@ public class AvroRpcWorkflowManagerClient implements WorkflowManagerClient {
 
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(AvroRpcWorkflowManagerClient.class);
 
-    private Transceiver client;
-    private org.apache.oodt.cas.workflow.struct.avrotypes.WorkflowManager proxy;
+    private transient Transceiver client;
+    private transient org.apache.oodt.cas.workflow.struct.avrotypes.WorkflowManager proxy;
     private URL workflowManagerUrl;
 
     public AvroRpcWorkflowManagerClient(URL url){


### PR DESCRIPTION
OPSUI attempts to serialize classes that have not implemented the Serializable interface. This pollutes the logs with a large number of NotSerializableException stack traces.

I added transient to the Transceiver and Proxy objects in Client classes to prevent attempts at Serialization, which solves the issue.