### PR TITLE
[OODT-1024] Add Kubernetes deployment files to RADIX archetype resources

### DIFF
--- a/mvn/archetypes/radix/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/mvn/archetypes/radix/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,7 +29,11 @@
       <includes>
         <include>README.txt</include>
         <include>docker-compose.yml</include>
+        <include>.gitignore</include>
       </includes>
+    </fileSet>
+    <fileSet filtered="true">
+      <directory>kubernetes</directory>
     </fileSet>
     <fileSet filtered="true" encoding="UTF-8">
       <directory>temp</directory>

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/.gitignore
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/.gitignore
@@ -1,0 +1,131 @@
+#Java Ignores
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+
+#Maven Ignores
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+# .idea/shelf
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+#Eclipse Ignore
+
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse
+
+# test by-products
+*.log
+
+# Apple OS X folder attributes
+.DS_Store
+
+# node_modules
+/react-components/oodt_fm_plugin/node_modules
+
+# npm build/Tarball ignores
+/react-components/oodt_fm_plugin/dist
+
+# Runtime package.json ignores
+/react-components/oodt_fm_plugin/package-lock.json

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-crawler.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-crawler.yaml
@@ -1,0 +1,60 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-crawler
+  name: ${artifactId}-crawler
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: ${artifactId}-crawler
+    spec:
+      containers:
+      - env:
+        - name: BACKUP_DIR
+          value: /tmp
+        - name: FAILURE_DIR
+          value: /tmp
+        - name: FILEMGR_URL
+          value: http://filemgr:9000
+        - name: PUSHPULL_MET_FILE_EXT
+          value: met
+        - name: RELATIVE_PRODUCT_PATH
+        - name: WORKFLOW_URL
+          value: http://workflow:9002
+        image: ${artifactId}-crawler:1.0-SNAPSHOT
+        name: ${artifactId}-crawler
+        resources: {}
+        volumeMounts:
+        - mountPath: /oodt/crawler/policy
+          name: ${artifactId}-crawler-policy
+        - mountPath: /oodt/crawler/logs
+          name: ${artifactId}-logs
+        - mountPath: /oodt/data
+          name: ${artifactId}-data
+        - mountPath: /tmp
+          name: ${artifactId}-temp
+      restartPolicy: Always
+      volumes:
+      - name: ${artifactId}-crawler-policy
+        persistentVolumeClaim:
+          claimName: ${artifactId}-crawler-policy
+      - name: ${artifactId}-logs
+        persistentVolumeClaim:
+          claimName: ${artifactId}-logs
+      - name: ${artifactId}-data
+        persistentVolumeClaim:
+          claimName: ${artifactId}-data
+      - name: ${artifactId}-temp
+        persistentVolumeClaim:
+          claimName: ${artifactId}-temp
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-filemgr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-filemgr.yaml
@@ -1,0 +1,53 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-filemgr
+  name: ${artifactId}-filemgr
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: ${artifactId}-filemgr
+    spec:
+      containers:
+      - env:
+        - name: SOLR_URL
+          value: http://solr:8983
+        image: ${artifactId}-filemgr:1.0-SNAPSHOT
+        name: ${artifactId}-filemgr
+        ports:
+        - containerPort: 9000
+        resources: {}
+        volumeMounts:
+        - mountPath: /oodt/filemgr/policy
+          name: ${artifactId}-filemgr-policy
+        - mountPath: /oodt/filemgr/logs
+          name: ${artifactId}-logs
+        - mountPath: /oodt/data
+          name: ${artifactId}-data
+        - mountPath: /tmp
+          name: ${artifactId}-temp
+      restartPolicy: Always
+      volumes:
+      - name: ${artifactId}-filemgr-policy
+        persistentVolumeClaim:
+          claimName: ${artifactId}-filemgr-policy
+      - name: ${artifactId}-logs
+        persistentVolumeClaim:
+          claimName: ${artifactId}-logs
+      - name: ${artifactId}-data
+        persistentVolumeClaim:
+          claimName: ${artifactId}-data
+      - name: ${artifactId}-temp
+        persistentVolumeClaim:
+          claimName: ${artifactId}-temp
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-opsui.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-opsui.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-opsui
+  name: ${artifactId}-opsui
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: ${artifactId}-opsui
+    spec:
+      containers:
+      - env:
+        - name: FILEMGR_URL
+          value: http://filemgr:9000
+        - name: GANGLIA_URL
+        - name: RESMGR_URL
+          value: http://resmgr:9001
+        - name: WORKFLOW_URL
+          value: http://workflow:9002
+        image: ${artifactId}-opsui:1.0-SNAPSHOT
+        name: ${artifactId}-opsui
+        ports:
+        - containerPort: 8080
+        resources: {}
+        volumeMounts:
+        - mountPath: /oodt/workflow/policy
+          name: ${artifactId}-workflow-policy
+        - mountPath: /oodt/pcs/policy
+          name: ${artifactId}-pcs-policy
+      restartPolicy: Always
+      volumes:
+      - name: ${artifactId}-workflow-policy
+        persistentVolumeClaim:
+          claimName: ${artifactId}-workflow-policy
+      - name: ${artifactId}-pcs-policy
+        persistentVolumeClaim:
+          claimName: ${artifactId}-pcs-policy
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-resmgr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-resmgr.yaml
@@ -1,0 +1,50 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-resmgr
+  name: ${artifactId}-resmgr
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: ${artifactId}-resmgr
+    spec:
+      containers:
+      - image: ${artifactId}-resmgr:1.0-SNAPSHOT
+        name: ${artifactId}-resmgr
+        ports:
+        - containerPort: 9001
+        resources: {}
+        volumeMounts:
+        - mountPath: /oodt/resmgr/policy
+          name: ${artifactId}-resmgr-policy
+        - mountPath: /oodt/data
+          name: ${artifactId}-data
+        - mountPath: /oodt/resmgr/logs
+          name: ${artifactId}-logs
+        - mountPath: /tmp
+          name: ${artifactId}-temp
+      restartPolicy: Always
+      volumes:
+      - name: ${artifactId}-resmgr-policy
+        persistentVolumeClaim:
+          claimName: ${artifactId}-resmgr-policy
+      - name: ${artifactId}-data
+        persistentVolumeClaim:
+          claimName: ${artifactId}-data
+      - name: ${artifactId}-logs
+        persistentVolumeClaim:
+          claimName: ${artifactId}-logs
+      - name: ${artifactId}-temp
+        persistentVolumeClaim:
+          claimName: ${artifactId}-temp
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-solr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-solr.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-solr
+  name: ${artifactId}-solr
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: ${artifactId}-solr
+    spec:
+      containers:
+      - image: ${artifactId}-solr:1.0-SNAPSHOT
+        name: ${artifactId}-solr
+        ports:
+        - containerPort: 8983
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-workflow.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/deployment-workflow.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-workflow
+  name: ${artifactId}-workflow
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: ${artifactId}-workflow
+    spec:
+      containers:
+      - env:
+        - name: RESMGR_URL
+          value: http://resmgr:9001
+        image: ${artifactId}-workflow:1.0-SNAPSHOT
+        name: ${artifactId}-workflow
+        ports:
+        - containerPort: 9002
+        resources: {}
+        volumeMounts:
+        - mountPath: /oodt/workflow/policy
+          name: ${artifactId}-workflow-policy
+        - mountPath: /oodt/workflow/logs
+          name: ${artifactId}-logs
+        - mountPath: /tmp
+          name: ${artifactId}-temp
+      restartPolicy: Always
+      volumes:
+      - name: ${artifactId}-workflow-policy
+        persistentVolumeClaim:
+          claimName: ${artifactId}-workflow-policy
+      - name: ${artifactId}-logs
+        persistentVolumeClaim:
+          claimName: ${artifactId}-logs
+      - name: ${artifactId}-temp
+        persistentVolumeClaim:
+          claimName: ${artifactId}-temp
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-filemgr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-filemgr.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-filemgr
+  name: ${artifactId}-filemgr
+spec:
+  ports:
+  - name: "9000"
+    port: 9000
+    targetPort: 9000
+  selector:
+    io.kompose.service: ${artifactId}-filemgr
+status:
+  loadBalancer: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-opsui.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-opsui.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-opsui
+  name: ${artifactId}-opsui
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 8080
+  selector:
+    io.kompose.service: ${artifactId}-opsui
+status:
+  loadBalancer: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-resmgr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-resmgr.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-resmgr
+  name: ${artifactId}-resmgr
+spec:
+  ports:
+  - name: "9001"
+    port: 9001
+    targetPort: 9001
+  selector:
+    io.kompose.service: ${artifactId}-resmgr
+status:
+  loadBalancer: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-solr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-solr.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-solr
+  name: ${artifactId}-solr
+spec:
+  ports:
+  - name: "8983"
+    port: 8983
+    targetPort: 8983
+  selector:
+    io.kompose.service: ${artifactId}-solr
+status:
+  loadBalancer: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-workflow.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/service-workflow.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ../docker-compose.yml
+    kompose.version: 1.18.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-workflow
+  name: ${artifactId}-workflow
+spec:
+  ports:
+  - name: "9002"
+    port: 9002
+    targetPort: 9002
+  selector:
+    io.kompose.service: ${artifactId}-workflow
+status:
+  loadBalancer: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-data.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-data.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-data
+  name: ${artifactId}-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-logs.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-logs.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-logs
+  name: ${artifactId}-logs
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-crawler.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-crawler.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-crawler-policy
+  name: ${artifactId}-crawler-policy
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-filemgr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-filemgr.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-filemgr-policy
+  name: ${artifactId}-filemgr-policy
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-pcs.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-pcs.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-pcs-policy
+  name: ${artifactId}-pcs-policy
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-resmgr.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-resmgr.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-resmgr-policy
+  name: ${artifactId}-resmgr-policy
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-workflow.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-policy-workflow.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-workflow-policy
+  name: ${artifactId}-workflow-policy
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-temp.yaml
+++ b/mvn/archetypes/radix/src/main/resources/archetype-resources/kubernetes/vol-temp.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: ${artifactId}-temp
+  name: ${artifactId}-temp
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}


### PR DESCRIPTION
For the containerized deployment of OODT, each component was assigned a Dockerfile and integrated into the maven build process using the dockerfile-maven plugin. This issue aims to add a Kubernetes configuration in addition to the docker-compose.yml files so that it can be deployed in Kubernetes clusters.