### PR TITLE
[OODT-1031] Updated filemgr, workflow manager and resource manager starters to use XML RPC by default

### DIFF
--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/FileManagerServer.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/FileManagerServer.java
@@ -27,7 +27,11 @@ import org.apache.oodt.cas.filemgr.catalog.Catalog;
  *
  */
 public interface FileManagerServer {
-
+    
+    String FILEMGR_PROPERTIES_FILE_SYSTEM_PROPERTY = "org.apache.oodt.cas.filemgr.properties";
+    String FILEMGR_SERVER_SYSTEM_PROPERTY = "filemgr.server";
+    String FILEMGR_CLIENT_SYSTEM_PROPERTY = "filemgr.client";
+    
     /**
      *
      * <p>Preparing and starting up the rpc server.</p>

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/util/RpcCommunicationFactory.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/util/RpcCommunicationFactory.java
@@ -22,6 +22,8 @@ import org.apache.oodt.cas.filemgr.system.FileManagerClient;
 import org.apache.oodt.cas.filemgr.system.FileManagerServer;
 import org.apache.oodt.cas.filemgr.system.rpc.FileManagerClientFactory;
 import org.apache.oodt.cas.filemgr.system.rpc.FileManagerServerFactory;
+import org.apache.oodt.cas.filemgr.system.rpc.XmlRpcFileManagerClientFactory;
+import org.apache.oodt.cas.filemgr.system.rpc.XmlRpcFileManagerServerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,11 +44,11 @@ public class RpcCommunicationFactory {
 
     private static Logger LOG = Logger.getLogger(RpcCommunicationFactory.class
             .getName());
-
-    private static String getClientFactoryName(){
-        return System.getProperty("filemgr.client",
-                "org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerClientFactory");
-   }
+    
+    private static String getClientFactoryName() {
+        return System.getProperty(FileManagerServer.FILEMGR_CLIENT_SYSTEM_PROPERTY,
+                XmlRpcFileManagerClientFactory.class.getName());
+    }
 
     /**
      * Set properties from filemgr.properties file
@@ -54,8 +56,8 @@ public class RpcCommunicationFactory {
      */
     private static void setPror(){
         // set up the configuration, if there is any
-        if (System.getProperty("org.apache.oodt.cas.filemgr.properties") != null) {
-            String configFile = System.getProperty("org.apache.oodt.cas.filemgr.properties");
+        if (System.getProperty(FileManagerServer.FILEMGR_PROPERTIES_FILE_SYSTEM_PROPERTY) != null) {
+            String configFile = System.getProperty(FileManagerServer.FILEMGR_PROPERTIES_FILE_SYSTEM_PROPERTY);
 
             LOG.log(Level.INFO, "Loading File Manager Configuration Properties from: [" + configFile + "]");
 
@@ -126,8 +128,8 @@ public class RpcCommunicationFactory {
     public static FileManagerServer createServer(int port) throws IOException {
         setPror();
 
-        String serverFactory = System.getProperty("filemgr.server",
-                "org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerServerFactory");
+        String serverFactory = System.getProperty(FileManagerServer.FILEMGR_SERVER_SYSTEM_PROPERTY,
+                XmlRpcFileManagerServerFactory.class.getName());
 
         LOG.log(Level.INFO, "Init. server's factory class: " + serverFactory);
 

--- a/filemgr/src/main/resources/filemgr.properties
+++ b/filemgr/src/main/resources/filemgr.properties
@@ -18,8 +18,8 @@
 # rpc configuration, uncomment the avro implementations to use AvroRPC
 #filemgr.server=org.apache.oodt.cas.filemgr.system.rpc.XmlRpcFileManagerServerFactory
 #filemgr.client=org.apache.oodt.cas.filemgr.system.rpc.XmlRpcFileManagerClientFactory
-filemgr.server=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerServerFactory
-filemgr.client=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerClientFactory
+filemgr.server=org.apache.oodt.cas.filemgr.system.rpc.XmlRpcFileManagerServerFactory
+filemgr.client=org.apache.oodt.cas.filemgr.system.rpc.XmlRpcFileManagerClientFactory
 
 # repository factory
 filemgr.repository.factory=org.apache.oodt.cas.filemgr.repository.XMLRepositoryManagerFactory

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
@@ -72,8 +72,8 @@ public class AvroRpcResourceManager implements org.apache.oodt.cas.resource.stru
 
         List<String> propertiesFiles = new ArrayList<>();
         // set up the configuration, if there is any
-        if (System.getProperty("org.apache.oodt.cas.resource.properties") != null) {
-            propertiesFiles.add(System.getProperty("org.apache.oodt.cas.resource.properties"));
+        if (System.getProperty(ResourceManager.RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY) != null) {
+            propertiesFiles.add(System.getProperty(ResourceManager.RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY));
         }
 
         configurationManager = ConfigurationManagerFactory

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/ResourceManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/ResourceManager.java
@@ -19,6 +19,11 @@ package org.apache.oodt.cas.resource.system;
 
 public interface ResourceManager {
 
+    String RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY = "org.apache.oodt.cas.resource.properties";
+    String RESMGR_SYSTEM_PROPERTY = "resmgr.manager";
+    String RESMGR_CLIENT_SYSTEM_PROPERTY = "resmgr.manager.client";
+    
+    
     void startUp() throws Exception;
 
     boolean isAlive();

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/XmlRpcResourceManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/XmlRpcResourceManager.java
@@ -77,8 +77,8 @@ public class XmlRpcResourceManager implements ResourceManager{
         this.port = port;
         List<String> propertiesFiles = new ArrayList<>();
         // set up the configuration, if there is any
-        if (System.getProperty("org.apache.oodt.cas.resource.properties") != null) {
-            propertiesFiles.add(System.getProperty("org.apache.oodt.cas.resource.properties"));
+        if (System.getProperty(ResourceManager.RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY) != null) {
+            propertiesFiles.add(System.getProperty(ResourceManager.RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY));
         }
 
         configurationManager = ConfigurationManagerFactory.getConfigurationManager(Component.RESOURCE_MANAGER, propertiesFiles);

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/rpc/ResourceManagerFactory.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/rpc/ResourceManagerFactory.java
@@ -19,27 +19,30 @@ package org.apache.oodt.cas.resource.system.rpc;
 
 import org.apache.oodt.cas.resource.system.ResourceManager;
 import org.apache.oodt.cas.resource.system.ResourceManagerClient;
+import org.apache.oodt.cas.resource.system.XmlRpcResourceManager;
+import org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 
 public class ResourceManagerFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(ResourceManagerFactory.class);
-
+    
     private static void loadProperties() {
         // set up the configuration, if there is any
-        if (System.getProperty("org.apache.oodt.cas.resource.properties") != null) {
-            String configFile = System.getProperty("org.apache.oodt.cas.resource.properties");
+        if (System.getProperty(ResourceManager.RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY) != null) {
+            String configFile = System.getProperty(ResourceManager.RESMGR_PROPERTIES_FILE_SYSTEM_PROPERTY);
 
-            logger.info("Loading File Manager Configuration Properties from: [{}]", configFile);
+            logger.info("Loading resource manager configuration properties from: [{}]", configFile);
             try {
                 System.getProperties().load(new FileInputStream(new File(configFile)));
-            } catch (Exception e) {
+            } catch (IOException e) {
                 logger.error("Error loading configuration properties from: [{}]", configFile);
             }
         }
@@ -47,8 +50,8 @@ public class ResourceManagerFactory {
 
     public static ResourceManager getResourceManager(int port) throws Exception {
         loadProperties();
-        String resourceManagerClass = System.getProperty("resmgr.manager",
-                "org.apache.oodt.cas.resource.system.AvroRpcResourceManager");
+        String resourceManagerClass = System.getProperty(ResourceManager.RESMGR_SYSTEM_PROPERTY,
+                XmlRpcResourceManager.class.getName());
 
         logger.info("Creating resource manager {} at port: {}", resourceManagerClass, port);
 
@@ -66,8 +69,8 @@ public class ResourceManagerFactory {
 
     public static ResourceManagerClient getResourceManagerClient(URL url) throws Exception {
         loadProperties();
-        String resMgrClientClass = System.getProperty("resmgr.manager.client",
-                "org.apache.oodt.cas.resource.system.AvroRpcResourceManagerClient");
+        String resMgrClientClass = System.getProperty(ResourceManager.RESMGR_CLIENT_SYSTEM_PROPERTY,
+                XmlRpcResourceManagerClient.class.getName());
 
         logger.info("Creating resource manager client {}", resMgrClientClass);
 

--- a/resource/src/main/resources/resource.properties
+++ b/resource/src/main/resources/resource.properties
@@ -17,8 +17,8 @@
 # Properties required to configure the Resource Manager
 
 # Client and server classes to be used as resource managers
-resmgr.manager=org.apache.oodt.cas.resource.system.AvroRpcResourceManager
-resmgr.manager.client=org.apache.oodt.cas.resource.system.AvroRpcResourceManagerClient
+resmgr.manager=org.apache.oodt.cas.resource.system.XmlRpcResourceManager
+resmgr.manager.client=org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient
 
 # resource spark master
 resource.runner.spark.host = mesos://<ip>:5050

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManager.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManager.java
@@ -83,7 +83,13 @@ public class AvroRpcWorkflowManager implements WorkflowManager,org.apache.oodt.c
                 port, System.getProperty("user.name", "unknown"));
 
         Preconditions.checkArgument(port > 0, "Must specify a port greater than 0");
-
+    
+        try {
+            loadProperties();
+        } catch (IOException e) {
+            logger.error("Error occurred when loading properties", e);
+        }
+    
         logger.debug("Getting workflow engine");
         engine = getWorkflowEngineFromProperty();
         if(engine == null){

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/WorkflowManager.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/WorkflowManager.java
@@ -8,7 +8,12 @@ package org.apache.oodt.cas.workflow.system;
 public interface WorkflowManager {
 
     String PROPERTIES_FILE_PROPERTY = "org.apache.oodt.cas.workflow.properties";
+    String DEFAULT_PROPERTIES_FILE = "workflow.properties";
+    
     String WORKFLOW_ENGINE_FACTORY_PROPERTY = "workflow.engine.factory";
+    String WORKFLOW_SERVER_FACTORY_PROPERTY = "workflow.server.factory";
+    String WORKFLOW_CLIENT_FACTORY_PROPERTY = "workflow.client.factory";
+    
     String ENGINE_RUNNER_FACTORY_PROPERTY = "workflow.engine.runner.factory";
     String WORKFLOW_REPOSITORY_FACTORY_PROPERTY = "workflow.repo.factory";
     int DEFAULT_WEB_SERVER_PORT = 9001;

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/rpc/RpcCommunicationFactory.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/rpc/RpcCommunicationFactory.java
@@ -82,10 +82,15 @@ public class RpcCommunicationFactory {
         String propertiesFile = System.getProperty(WorkflowManager.PROPERTIES_FILE_PROPERTY, WorkflowManager.DEFAULT_PROPERTIES_FILE);
         InputStream prpFileStream = RpcCommunicationFactory.class.getResourceAsStream(propertiesFile);
         Properties properties = new Properties();
-        try {
-            properties.load(prpFileStream);
-        } catch (IOException e) {
-            logger.error("An error occurred when loading properties file: {}", propertiesFile, e);
+    
+        if (prpFileStream != null) {
+            try {
+                properties.load(prpFileStream);
+            } catch (IOException e) {
+                logger.error("An error occurred when loading properties file: {}", propertiesFile, e);
+            }
+        } else {
+            logger.warn("Properties file: '{}' could not be found. Skipped loading properties", propertiesFile);
         }
         
         return properties;

--- a/workflow/src/main/resources/workflow.properties
+++ b/workflow/src/main/resources/workflow.properties
@@ -16,8 +16,8 @@
 # Properties required to configure the Workflow Manager
 
 #Rpc workflow communication class
-workflow.server.factory = org.apache.oodt.cas.workflow.system.rpc.AvroRpcWorkflowManagerFactory
-workflow.client.factory = org.apache.oodt.cas.workflow.system.rpc.AvroRpcWorkflowManagerFactory
+workflow.server.factory = org.apache.oodt.cas.workflow.system.rpc.XmlRpcWorkflowManagerFactory
+workflow.client.factory = org.apache.oodt.cas.workflow.system.rpc.XmlRpcWorkflowManagerFactory
 
 # workflow repository factory
 workflow.repo.factory = org.apache.oodt.cas.workflow.repository.XMLWorkflowRepositoryFactory


### PR DESCRIPTION
See [OODT1031](https://issues.apache.org/jira/projects/OODT/issues/OODT-1031?filter=allopenissues&orderby=created+DESC%2C+priority+DESC%2C+updated+DESC).

Updated the file manager, workflow manager and resource manager main classes to load the corresponding properties files properly and use XML rpc versions of clients and servers by default in order to keep backward compatibility with OODT 1.x releases.