### PR TITLE
JDK11 migration - Update project dependencies and fix failed unit tests

### DIFF
--- a/commons/src/main/java/org/apache/oodt/commons/ConfiguredTestCase.java
+++ b/commons/src/main/java/org/apache/oodt/commons/ConfiguredTestCase.java
@@ -64,16 +64,16 @@ public abstract class ConfiguredTestCase extends TestCase {
 
 	/** Test configuration, as a document. */
 	private static final String TSTDOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE configuration PUBLIC"
-		+ " \"-//JPL//DTD EDA Configuration 1.0//EN\" \"http://oodt.jpl.nasa.gov/edm-commons/Configuration.dtd\">\n"
-		+ "<configuration><webServer><host>www.jpl.nasa.gov</host><port>81</port><dir>/non/existent/htdocs</dir>"
-		+ "</webServer><nameServer><iiop><version>1</version><host>oodt.jpl.nasa.gov</host><port>82</port>"
+		+ " \"-//JPL//DTD EDA Configuration 1.0//EN\" \"oodt.apache.org\">\n"
+		+ "<configuration><webServer><host>oodt.apache.org</host><port>81</port><dir>/non/existent/htdocs</dir>"
+		+ "</webServer><nameServer><iiop><version>1</version><host>oodt.apache.org</host><port>82</port>"
 		+ "<objectKey>StandardNS/NameServer%2DPOA/_test</objectKey></iiop></nameServer><ldapServer>"
-		+ "<host>ldap.jpl.nasa.gov</host><port>83</port><managerDN>cn=GeorgeTestostoles,dc=test,dc=zone</managerDN>"
+		+ "<host>oodt.apache.org</host><port>83</port><managerDN>cn=GeorgeTestostoles,dc=test,dc=zone</managerDN>"
 		+ "<password>h1ghly;s3cr3t</password></ldapServer><xml><parser>crimson</parser><entityRef>"
 		+ "<dir>/non/existent/htdocs/xml</dir><dir>/non/existent/htdocs/dtd</dir></entityRef></xml><serverMgr>"
 		+ "<port>84</port></serverMgr><properties><key>global</key><value>1</value><key>override</key><value>2</value>"
 		+ "</properties><programs><execServer><class>TestServer</class><objectKey>urn:eda:rmi:TestObject</objectKey>"
-		+ "<host>oodt.jpl.nasa.gov</host><properties><key>local</key><value>3</value><key>override</key><value>4</value>"
+		+ "<host>oodt.apache.org</host><properties><key>local</key><value>3</value><key>override</key><value>4</value>"
 		+ "</properties></execServer><client><class>TestClient</class><properties><key>local</key><value>5</value>"
 		+ "<key>override</key><value>6</value></properties></client></programs></configuration>";
 }

--- a/commons/src/test/java/org/apache/oodt/commons/util/XMLTest.java
+++ b/commons/src/test/java/org/apache/oodt/commons/util/XMLTest.java
@@ -59,7 +59,7 @@ public class XMLTest extends TestCase {
 		String result = XML.serialize(doc);
 		crc.update(result.getBytes());
 		long value = crc.getValue();
-		assertTrue("Stringified DOM document CRC mismatch, got value = " + value, 3880488030L == value || 2435419114L == value || /* added by Chris Mattmann: pretty print fix */3688328384L == value || /* other newline treatment */ 750262163L == value || 3738296466L == value /* Apache incubator warmed up the file, so it suffered thermal expansion */ || 1102069581L == value /* lewismc and his ALv2 header. */ || 3026567548L == value /* Windows 2008 Server CRC value */);
+		assertTrue("Stringified DOM document CRC mismatch, got value = " + value, 3880488030L == value || 2435419114L == value || /* added by Chris Mattmann: pretty print fix */3688328384L == value || /* other newline treatment */ 750262163L == value || 3738296466L == value /* Apache incubator warmed up the file, so it suffered thermal expansion */ || 1102069581L == value /* lewismc and his ALv2 header. */ || 3026567548L == value /* Windows 2008 Server CRC value */ || 2790989364L == value);
 	}
 
 	/** Test the {@link XML#createSAXParser} method.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@ the License.
     <docsSrc>${basedir}/src/site/xdoc</docsSrc>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jena.version>3.0.0</jena.version>
+    <jena.version>3.17.0</jena.version>
     <wicket.version>1.4.17</wicket.version>
     <jetty.version>6.1.25</jetty.version>
     <sonar.language>java</sonar.language>
@@ -78,12 +78,17 @@ the License.
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-ipc</artifactId>
-        <version>1.8.2</version>
+        <version>1.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
-        <version>1.8.2</version>
+        <version>1.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-ipc-jetty</artifactId>
+        <version>1.10.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -93,13 +98,13 @@ the License.
       <dependency>
         <groupId>com.icegreen</groupId>
         <artifactId>greenmail</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.15</version>
         <exclusions>
           <exclusion>
             <!-- xom is an optional dependency of xstream. Its also an Apache incompatible license -->
@@ -111,12 +116,12 @@ the License.
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.3.1</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.10</version>
+        <version>1.15</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -131,7 +136,7 @@ the License.
       <dependency>
         <groupId>commons-httpclient</groupId>
         <artifactId>commons-httpclient</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
       </dependency>
       <dependency>
        <groupId>org.apache.httpcomponents</groupId>
@@ -142,12 +147,12 @@ the License.
          <groupId>commons-logging</groupId>
        </exclusion>
       </exclusions>
-        <version>4.4</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
@@ -182,12 +187,12 @@ the License.
       <dependency>
         <groupId>hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>1.8.0.7</version>
+        <version>1.8.0.10</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
       </dependency>
       <dependency>
         <groupId>jgraph</groupId>
@@ -197,7 +202,7 @@ the License.
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.9.4</version>
+        <version>2.10.9</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -207,12 +212,12 @@ the License.
       <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.17</version>
       </dependency>
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>6.0.3</version>
+        <version>8.0.22</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.nekohtml</groupId>
@@ -222,7 +227,7 @@ the License.
       <dependency>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>4.4.0</version>
       </dependency>
       <dependency>
         <!--
@@ -242,22 +247,22 @@ the License.
       <dependency>
         <groupId>net.sf.jung</groupId>
         <artifactId>jung-algorithms</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>net.sf.jung</groupId>
         <artifactId>jung-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>net.sf.jung</groupId>
         <artifactId>jung-graph-impl</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>net.sf.jung</groupId>
         <artifactId>jung-visualization</artifactId>
-        <version>2.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>net.sf.saxon</groupId>
@@ -267,17 +272,17 @@ the License.
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.12</version>
+        <version>1.20</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-recipes</artifactId>
-        <version>3.3.0</version>
+        <version>5.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>3.3.0</version>
+        <version>5.1.0</version>
         <exclusions>
           <exclusion>
             <groupId>log4j</groupId>
@@ -288,23 +293,23 @@ the License.
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-        <version>3.1.6</version>
+        <version>3.4.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-extension-providers</artifactId>
-        <version>3.1.6</version>
+        <version>3.4.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-transports-local</artifactId>
-        <version>3.1.6</version>
+        <version>3.4.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.ftpserver</groupId>
         <artifactId>ftpserver-core</artifactId>
-        <version>1.0.6</version>
+        <version>1.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.javamail</groupId>
@@ -433,7 +438,7 @@ the License.
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi</artifactId>
-        <version>3.2-FINAL</version>
+        <version>4.1.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>
@@ -448,12 +453,12 @@ the License.
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-core</artifactId>
-        <version>1.13</version>
+        <version>1.25</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-parsers</artifactId>
-        <version>1.13</version>
+        <version>1.25</version>
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>
@@ -473,12 +478,12 @@ the License.
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.3.4</version>
+        <version>1.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.4</version>
+        <version>4.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -490,7 +495,7 @@ the License.
       <dependency>
         <groupId>org.jglobus</groupId>
         <artifactId>gss</artifactId>
-        <version>2.0.6</version>
+        <version>2.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.jglobus</groupId>
@@ -500,7 +505,7 @@ the License.
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.9.5</version>
+        <version>1.10.19</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -521,13 +526,13 @@ the License.
       <dependency>
         <groupId>org.python</groupId>
         <artifactId>jython</artifactId>
-        <version>2.2-beta1</version>
+        <version>2.7.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>
         <artifactId>reflections</artifactId>
-        <version>0.9.9-RC1</version>
+        <version>0.9.12</version>
       </dependency>
       <dependency>
         <groupId>org.safehaus.jug</groupId>
@@ -539,38 +544,38 @@ the License.
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.12</version>
+        <version>2.0.0-alpha1</version>
       </dependency>
       <!-- Temporary fix to send java.util.Logger logs to SLF4J -->
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
-        <version>1.7.12</version>
+        <version>2.0.0-alpha1</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.12</version>
+        <version>2.0.0-alpha1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>2.5.4</version>
+        <version>5.3.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>2.5.4</version>
+        <version>5.3.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>2.5.4</version>
+        <version>5.3.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -580,12 +585,12 @@ the License.
       <dependency>
         <groupId>xalan</groupId>
         <artifactId>xalan</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.9.1</version>
+        <version>2.12.1</version>
       </dependency>
       <dependency>
         <groupId>xmlrpc</groupId>
@@ -595,7 +600,7 @@ the License.
       <dependency>
         <groupId>xmlunit</groupId>
         <artifactId>xmlunit</artifactId>
-        <version>1.4</version>
+        <version>1.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -620,9 +625,9 @@ mm
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>
@@ -635,19 +640,22 @@ mm
       </plugin>
       <plugin>
         <artifactId>maven-eclipse-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.10</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
         <configuration>
           <includes>
             <include>**/*Test*.java</include>
           </includes>
+          <reuseForks>false</reuseForks>
+          <forkCount>1</forkCount>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>3.2.0</version>
         <configuration>
           <charset>UTF-8</charset>
           <docencoding>UTF-8</docencoding>
@@ -689,12 +697,11 @@ mm
       <!-- Produce JavaDoc -->
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.2.0</version>
         <configuration>
           <charset>UTF-8</charset>
           <docencoding>UTF-8</docencoding>
           <encoding>UTF-8</encoding>
-          <aggregate>true</aggregate>
           <source>1.7</source>
         </configuration>
       </plugin>

--- a/curator/sso/pom.xml
+++ b/curator/sso/pom.xml
@@ -50,7 +50,7 @@ the License.
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -59,7 +59,7 @@ the License.
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.oodt</groupId>

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -219,6 +219,16 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-ipc-netty</artifactId>
+      <version>1.10.1</version>
+    </dependency>
   </dependencies>
   <build>
     <directory>target</directory>

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/AvroFileManagerClient.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/AvroFileManagerClient.java
@@ -18,7 +18,7 @@
 package org.apache.oodt.cas.filemgr.system;
 
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.NettyTransceiver;
+import org.apache.avro.ipc.netty.NettyTransceiver;
 import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 import org.apache.oodt.cas.filemgr.datatransfer.DataTransfer;
@@ -88,7 +88,7 @@ public class AvroFileManagerClient implements FileManagerClient {
         try {
             this.fileManagerUrl = url;
             InetSocketAddress inetSocketAddress = new InetSocketAddress(url.getHost(), this.fileManagerUrl.getPort());
-            this.client = new NettyTransceiver(inetSocketAddress, 40000L);
+            this.client = new NettyTransceiver(inetSocketAddress, 40000);
             proxy = (AvroFileManager) SpecificRequestor.getClient(AvroFileManager.class, client);
         } catch (IOException e) {
             logger.error("Error occurred when creating file manager: {}", url, e);

--- a/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/AvroFileManagerServer.java
+++ b/filemgr/src/main/java/org/apache/oodt/cas/filemgr/system/AvroFileManagerServer.java
@@ -19,7 +19,7 @@
 package org.apache.oodt.cas.filemgr.system;
 
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.NettyServer;
+import org.apache.avro.ipc.netty.NettyServer;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.specific.SpecificResponder;
 import org.apache.oodt.cas.filemgr.catalog.Catalog;

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestDumpMetadataCliAction.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestDumpMetadataCliAction.java
@@ -72,10 +72,10 @@ public class TestDumpMetadataCliAction extends TestCase {
       assertEquals(
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
           + "<cas:metadata xmlns:cas=\"http://oodt.jpl.nasa.gov/1.0/cas\">\n"
-          + "<keyval type=\"vector\">\n"
-          + "<key>Filename</key>\n"
-          + "<val>data.dat</val>\n"
-          + "</keyval>\n"
+          + "    <keyval type=\"vector\">\n"
+          + "        <key>Filename</key>\n"
+          + "        <val>data.dat</val>\n"
+          + "    </keyval>\n"
           + "</cas:metadata>\n",
             printer.getPrintedMessages().get(0));
 
@@ -85,10 +85,10 @@ public class TestDumpMetadataCliAction extends TestCase {
       assertEquals(
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
             + "<cas:metadata xmlns:cas=\"http://oodt.jpl.nasa.gov/1.0/cas\">\n"
-            + "<keyval type=\"vector\">\n"
-            + "<key>Filename</key>\n"
-            + "<val>data.dat</val>\n"
-            + "</keyval>\n"
+            + "    <keyval type=\"vector\">\n"
+            + "        <key>Filename</key>\n"
+            + "        <val>data.dat</val>\n"
+            + "    </keyval>\n"
             + "</cas:metadata>\n",
             FileUtils.readFileToString(new File(tmpFile, FILE_NAME + ".met")));
    }

--- a/pcs/core/src/main/java/org/apache/oodt/pcs/tools/PCSHealthMonitor.java
+++ b/pcs/core/src/main/java/org/apache/oodt/pcs/tools/PCSHealthMonitor.java
@@ -30,7 +30,8 @@ import java.util.Vector;
 import java.util.logging.Level;
 
 //APACHE imports
-import org.apache.avro.ipc.NettyTransceiver;
+import org.apache.avro.AvroRemoteException;
+import org.apache.avro.ipc.netty.NettyTransceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 import org.apache.oodt.cas.resource.system.extern.AvroRpcBatchStub;
 import org.apache.oodt.cas.crawl.daemon.CrawlDaemonController;
@@ -623,7 +624,7 @@ public final class PCSHealthMonitor implements CoreMetKeys,
       client = new NettyTransceiver(new InetSocketAddress(node.getIpAddr().getPort()));
       proxy = (AvroRpcBatchStub) SpecificRequestor.getClient(AvroRpcBatchStub.class, client);
       return proxy.isAlive();
-    } catch (IOException e) {
+    } catch (IOException | AvroRemoteException e) {
       return false;
     }
   }

--- a/pcs/services/pom.xml
+++ b/pcs/services/pom.xml
@@ -51,13 +51,13 @@ the License.
     <dependency>
       <groupId>net.sf.json-lib</groupId>
       <artifactId>json-lib</artifactId>
-      <version>2.3</version>
+      <version>2.4</version>
       <classifier>jdk15</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-      <version>2.6.0</version>
+      <version>3.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.oodt</groupId>

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -117,7 +117,7 @@ the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.3.0</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/pge/src/test/java/org/apache/oodt/cas/pge/TestPGETaskInstance.java
+++ b/pge/src/test/java/org/apache/oodt/cas/pge/TestPGETaskInstance.java
@@ -465,7 +465,7 @@ public class TestPGETaskInstance {
       pgeTask.pgeMetadata.replaceMetadata(ATTEMPT_INGEST_ALL, Boolean.toString(true));
       pgeTask.setWorkflowInstId("WorkflowInstanceId");
 
-      pgeTask.setWmClient(createMock(WorkflowManagerClient.class));
+      pgeTask.setWmClient((WorkflowManagerClient) createMock(WorkflowManagerClient.class));
       expect(pgeTask.getWorkflowManagerClient()
               .updateWorkflowInstanceStatus(pgeTask.getWorkflowInstId(), CRAWLING.getWorkflowStatusName())
       ).andReturn(true);
@@ -483,7 +483,7 @@ public class TestPGETaskInstance {
       verify(pc);
 
       // Case: UpdateStatus Fail
-      pgeTask.setWmClient(createMock(WorkflowManagerClient.class));
+      pgeTask.setWmClient((WorkflowManagerClient) createMock(WorkflowManagerClient.class));
       expect(pgeTask.getWorkflowManagerClient().updateWorkflowInstanceStatus(pgeTask.getWorkflowInstId(),
             CRAWLING.getWorkflowStatusName())).andReturn(false);
       replay(pgeTask.getWorkflowManagerClient());
@@ -500,7 +500,7 @@ public class TestPGETaskInstance {
       verify(pc);
 
       // Case: UpdateStatus Success, VerifyIngest Fail
-      pgeTask.setWmClient(createMock(WorkflowManagerClient.class));
+      pgeTask.setWmClient((WorkflowManagerClient) createMock(WorkflowManagerClient.class));
       expect(pgeTask.getWorkflowManagerClient().updateWorkflowInstanceStatus(pgeTask.getWorkflowInstId(),
             CRAWLING.getWorkflowStatusName())).andReturn(true);
       replay(pgeTask.getWorkflowManagerClient());

--- a/resource/pom.xml
+++ b/resource/pom.xml
@@ -97,7 +97,7 @@ the License.
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4</version>
+        <version>2.22.2</version>
         <configuration>
           <forkMode>pertest</forkMode>
           <useSystemClassLoader>false</useSystemClassLoader>
@@ -163,6 +163,11 @@ the License.
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-ipc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-ipc-netty</artifactId>
+      <version>1.10.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/resource/src/main/java/org/apache/oodt/cas/resource/batchmgr/AvroRpcBatchMgrProxy.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/batchmgr/AvroRpcBatchMgrProxy.java
@@ -18,7 +18,7 @@
 package org.apache.oodt.cas.resource.batchmgr;
 
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.NettyTransceiver;
+import org.apache.avro.ipc.netty.NettyTransceiver;
 import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 import org.apache.oodt.cas.resource.structs.AvroTypeFactory;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManager.java
@@ -18,7 +18,7 @@
 package org.apache.oodt.cas.resource.system;
 
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.NettyServer;
+import org.apache.avro.ipc.netty.NettyServer;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.specific.SpecificResponder;
 import org.apache.oodt.cas.resource.scheduler.Scheduler;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/AvroRpcResourceManagerClient.java
@@ -18,7 +18,7 @@
 package org.apache.oodt.cas.resource.system;
 
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.NettyTransceiver;
+import org.apache.avro.ipc.netty.NettyTransceiver;
 import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 import org.apache.oodt.cas.cli.CmdLineUtility;

--- a/resource/src/main/java/org/apache/oodt/cas/resource/system/extern/AvroRpcBatchStub.java
+++ b/resource/src/main/java/org/apache/oodt/cas/resource/system/extern/AvroRpcBatchStub.java
@@ -18,7 +18,7 @@
 package org.apache.oodt.cas.resource.system.extern;
 
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.NettyServer;
+import org.apache.avro.ipc.netty.NettyServer;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.specific.SpecificResponder;
 import org.apache.oodt.cas.resource.structs.AvroTypeFactory;

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -60,6 +60,11 @@ the License.
       <artifactId>avro-ipc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-ipc-jetty</artifactId>
+      <version>1.10.1</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/engine/runner/AsynchronousLocalEngineRunner.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/engine/runner/AsynchronousLocalEngineRunner.java
@@ -114,6 +114,9 @@ public class AsynchronousLocalEngineRunner extends AbstractEngineRunnerBase {
         this.destroy();
       }
 
+      public void destroy() {
+      }
+
     };
 
     String id = "";

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManager.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManager.java
@@ -19,7 +19,7 @@ package org.apache.oodt.cas.workflow.system;
 
 import com.google.common.base.Preconditions;
 import org.apache.avro.AvroRemoteException;
-import org.apache.avro.ipc.HttpServer;
+import org.apache.avro.ipc.jetty.HttpServer;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.specific.SpecificResponder;
 import org.apache.oodt.cas.metadata.Metadata;

--- a/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManagerClient.java
+++ b/workflow/src/main/java/org/apache/oodt/cas/workflow/system/AvroRpcWorkflowManagerClient.java
@@ -18,7 +18,7 @@
 package org.apache.oodt.cas.workflow.system;
 
 import org.apache.avro.ipc.HttpTransceiver;
-import org.apache.avro.ipc.NettyTransceiver;
+import org.apache.avro.ipc.netty.NettyTransceiver;
 import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 import org.apache.oodt.cas.metadata.Metadata;


### PR DESCRIPTION
This PR is a head start for the project migration from JDK8 to JDK11.

Changes:
 
- Update module pom.xmls with latest 3rd party denendencies.
- Fixed couple of unit tests.