### PR TITLE
Move company logos off of the home page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -66,6 +66,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html">Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>

--- a/community.html
+++ b/community.html
@@ -68,6 +68,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html" >Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>
@@ -77,119 +80,110 @@
 </div>
 </nav>
 
-  <div class="container" >
-
-  <!-- Nav tabs -->
-  <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="active"><a href="#home" aria-controls="home" role="tab" data-toggle="tab">About</a></li>
-    <li role="presentation"><a href="#profile" aria-controls="profile" role="tab" data-toggle="tab">The Team</a></li>
-  </ul>
-
-  <!-- Tab panes -->
-  <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" id="home">
-        <div class="row col-md-6 col-md-offset-3">
+    <div class="row col-md-8 col-md-offset-2">
 <h1>Community</h1>
-Apache OODT has a dedicated community based globally. To keep in contact they make use of a variety of tools.
 
-<h2>Mailing Lists</h2>
-<p>Apache OODT runs a mailing list for general communication and development chat. To ask questions about Apache OODT join the dev@oodt.apache.org mailing list and say hello!</p>
+<h2>Get in touch</h2>
+<p>Apache OODT has a dedicated global community. To keep in touch, they make use of a variety of tools.</p>
 
-<h2>IRC</h2>
+<h3>Mailing Lists</h3>
+<p>Apache OODT runs a mailing list for general communication and development chat. To ask questions about Apache OODT join the mailing list and say hello!</p>
+<ul>
+  <li><a href="mailto:user@oodt.apache.org">user@oodt.apache.org</a> - to ask questions about the general use of Apache OODT</li>
+  <li><a href="mailto:dev@oodt.apache.org">dev@oodt.apache.org</a> - to ask questions about the development of Apache OODT</li>
+</ul>
+
+<h3>IRC</h3>
 <p>We also have an OODT IRC channel for real time OODT discussion, you can find this on Freenode at #oodt.</p>
 
 <p>If you don't haven an IRC client installed, you can still join the channel using the <a target="_blank" href="http://webchat.freenode.net/?channels=oodt">webchat</a> to stop by and introduce yourself!</p>
 
-<h2>Blog</h2>
+<h3>Blog</h3>
 <p>Keep up to date with News, Events and Tips and Tricks with our <a href="/blog"> new blog</a>.</p>
 <p>Similarly, if you have any OODT releated news, or interesting blog content, pop by our mailing list and tell us, we're always looking for interesting articles!</p>
 
-<h2>Social Media</h2>
+<h3>Social Media</h3>
 
-<h4>Follow our twitter account!</h4>
+<h4>Follow us on Twitter</h4>
 <a href="https://twitter.com/apache_oodt" class="twitter-follow-button" data-show-count="false" data-size="large" data-dnt="true">Follow @apache_oodt</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></a><br/>
-<h4>Join our facebook group!</h4>
-<img src="" alt="facebook logo" />
 <br/>
-<h4>If you use Google Plus you can find our community here!</h4>
-<script src="https://apis.google.com/js/platform.js" async defer></script>
-<g:community width="300" layout="landscape" href="https://plus.google.com/communities/109940995190375177195"></g:community>
+
+<h2>Developer community</h2>
+
+<h3>Current Project Lead</h3>
+<p>The chair has primary responsibility to the Board, and has the power to establish rules and procedures for the day to day management of the communities for which the PMC is responsible.</p>
+<p><strong>Imesha Sudasingha</strong></p>
+
+<h3>Project Management Committe (PMC) members</h3>
+<p>The PMC provides management and governance of the project. The canonical list is always available here.</p>
+
+<div class="row">
+  <div class="col-md-3">
+    <strong>Andrew Hart</strong><br/>
+    <strong>Angela Wang</strong><br/>
+    <strong>Arni Sumarlidason</strong><br/>
+    <strong>Billy Webb</strong><br/>
+    <strong>Brian Foster</strong><br/>
+    <strong>Bruce Barkstrom</strong><br/>
+    <strong>Cameron Goodale</strong><br/>
+    <strong>Chris Mattmann</strong><br/>
+    <strong>Dan Crichton</strong><br/>
+    <strong>Dana J Freeborn</strong><br/>
+    <strong>David Kale</strong><br/>
+    <strong>David Woollard</strong><br/>
+    <strong>Gabriel Resneck</strong><br/>
+    <strong>Gavin McDonald</strong><br/>
+    <strong>Ian Holsman</strong><br/>
   </div>
-
-    </div>
-    <div role="tabpanel" class="tab-pane" id="profile">
-      <div class="row col-md-6 col-md-offset-2">
-
-  <h1>What is it?</h1>
-  <p>Awarded 2003 NASA Software of the Year, Apache Object Oriented Data Technology (OODT) began at the Jet Propulsion Laboratory, in operations cataloging pictures of Mars and helping to detect cancer. Apache OODT is smart, open source software for science, research, or otherwise.</p>
-
-  <p>Apache OODT is the superior way to integrate and archive your processes, your data, and its metadata. It spans scientific and other disciplines and enable interoperability among data agnostic systems in the varying fields. Using OODT's framework of distributed objects and databases, the data collected by scientists and engineers in disparate disciplines can be jointly searched, stored, retrieved, and analyzed. It facilitates the creation, acquisition, and growth of data management and archiving systems.</p>
-
-  <h1>Why use it?</h1>
-  <strong>OODT is deployed operationally in:</strong>
-  <ul>
-    <li>DARPA's XDATA Presidential Big Data Initiative</li>
-    <li>NASA's Airborne Snow Observatory demonstration mission.</li>
-    <li>NASA's Carbon in Arctic Reservoirs Vulnerability Experiment</li>
-    <li>National Cancer Institute's Early Detection Research Network</li>
-    <li>NASA's Orbiting Carbon Observatory</li>
-    <li>The Sinai-Helmsley Alliance for Research Excellence data coordinating center project</li>
-    <li>MIT Haystack Observatory</li>
-    <li>NASA's Megacities Carbon Project</li>
-    <li>Children's Hospital of Los Angeles's Virtual Pediatric Intensive Care Unit</li>
-    <li>The Planetary Data System</li>
-    <li>NASA's Orbiting Carbon Observatory-2</li>
-    <li>NASA's Soil Moisture Active/Passive mission</li>
-    <li>The Square Kilometre Array South Africa project</li>
-    <li>NASA's Seawinds/QuickSCAT mission</li>
-    <li>and many more...</li>
-    <p>Processing pipelines are too often one-off custom solutions that fail to scale and evolve as systems evolve. Moreover, archived data undergoes a kind of atrophy as the tools used to analyze and process it are themselves one-off solutions with no maintenance. These haphazard approaches achieve only short term success, but are not effective in data search, discovery, analysis, cataloging, processing, or archiving. OODT replaces these manual, forgettable steps with reliable workflows through distributed data grids. OODT ensures the usability and value of data even after original developers move on.</p>
-
-    <h1>How?</h1>
-    <p>Haphazard processing pipelines are commonly made up of custom UNIX shell scripts and/or fragile custom written glue code of Java, Python, and Perl. OODT uses structured XML-based capturing of the processing pipeline that can be understood and modified by non-programmers to create, edit, manage and provision workflow and task execution.</p>
-
-
-    <h1>Prerequisites</h1>
-
-    <h2>Operating Systems</h2>
-
-    <ul>
-      <li>UNIX (Linux, OS/X, Solaris, BSD, etc.)</li>
-      <li>Windows with Cygwin</li>
-    </ul>
-    <h2>Software</h2>
-
-    <ul>
-      <li>Java and/or Python</li>
-      <li>Maven</li>
-    </ul>
-    <h2>Knowledge</h2>
-    <ul>
-      <li>XML</li>
-      <li>Java and/or Python (in order to customize and extend)</li>
-    </ul>
-</div>
-<div class="col-md-2">
-  <h2>Project Management Committee</h2>
-  <p>The PMC provides management and governance of the project. The canonical list is always available <a href="http://people.apache.org/phonebook.html">here</a>.</p>
-  Andrew Hart<br/>Angela Wang<br/>Brian Foster<br/>Bruce Barkstrom<br/>Chris<br/>Dan Crichton<br/>David Kale<br/>Dana J Freeborn<br/>Gabriel Resneck<br/>Gavin McDonald<br/>Cameron Goodale<br/>Ian Holsman<br/>Imesha Sudasingha<br/>Joshua Garcia<br/>Michael James Joyce<br/>John Steven Hughes<br/>Sean Kelly<br/>Lewis John McGibbney<br/>Luca Cinquini<br/>Tom Barber<br/>Chris Mattmann<br/>Michael Cayanan<br/>Nga Thien Chung<br/>Paul Ramirez<br/>Paul Vee<br/>Paul Zimdars<br/>Radu Manole<br/>Ricky Nguyen<br/>Rishi Verma<br/>Ross Laidlaw<br/>Sean Hardman<br/>Sheryl John<br/>Rajith Siriwardana<br/>Shakeh Elisabeth Khudikyan<br/>Sean McCleese<br/>Sam Park<br/>Michael Starch<br/>Sujen Shah<br/>Arni Sumarlidason<br/>Thomas Bennett<br/>Tyler Bui-Palsulich<br/>Varun Ratnakar<br/>Val Mallder<br/>Billy Webb<br/>David Woollard<br/>
-  <h2>(Former) Apache Incubator Mentors</h2>
-  <p>Mentors are long-term Apache members that provided guidance to our project during its Incubation.</p>
-
-  Justin Erenkrantz<br/>
-  Ross Gardler<br/>
-  Ian Holsman<br/>
-  Jean-Frederic Clere<br/>
-  Chris Mattmann<br/>
-  
-</div>
-
-    </div>
+  <div class="col-md-3">
+    <strong>Imesha Sudasingha</strong><br/>
+    <strong>John Steven Hughes</strong><br/>
+    <strong>Joshua Garcia</strong><br/>
+    <strong>Lewis John McGibbney</strong><br/>
+    <strong>Luca Cinquini</strong><br/>
+    <strong>Michael Cayanan</strong><br/>
+    <strong>Michael James Joyce</strong><br/>
+    <strong>Michael Starch</strong><br/>
+    <strong>Nadeeshan Gimhana</strong><br/>
+    <strong>Nga Thien Chung</strong><br/>
+    <strong>Paul Ramirez</strong><br/>
+    <strong>Paul Vee</strong><br/>
+    <strong>Paul Zimdars</strong><br/>
+    <strong>Radu Manole</strong><br/>
+    <strong>Rajith Siriwardana</strong><br/>    
   </div>
-
-  
+  <div class="col-md-3">
+    <strong>Ricky Nguyen</strong><br/>
+    <strong>Rishi Verma</strong><br/>
+    <strong>Ross Laidlaw</strong><br/>
+    <strong>Sam Park</strong><br/>
+    <strong>Sean Hardman</strong><br/>
+    <strong>Sean Kelly</strong><br/>
+    <strong>Sean McCleese</strong><br/>
+    <strong>Shakeh Elisabeth Khudikyan</strong><br/>
+    <strong>Sheryl John</strong><br/>
+    <strong>Sujen Shah</strong><br/>
+    <strong>Thomas Bennett</strong><br/>
+    <strong>Tom Barber</strong><br/>
+    <strong>Tyler Bui-Palsulich</strong><br/>
+    <strong>Val Mallder</strong><br/>
+    <strong>Varun Ratnakar</strong><br/>
+  </div>
 </div>
+
+<h3>(Former) Apache Incubator Mentors</h3>
+<p>Mentors are long-term Apache members that provided guidance to our project during its Incubation.</p>
+
+<strong>Chris Mattmann</strong><br/>
+<strong>Ian Holsman</strong><br/>
+<strong>Jean-Frederic Clere</strong><br/>
+<strong>Justin Erenkrantz</strong><br/>
+<strong>Ross Gardler</strong><br/>
+
+<br />
+</div>
+
   <footer class="sitefooter">
   <div class="container">
     <div class="row">
@@ -208,9 +202,6 @@ Apache OODT has a dedicated community based globally. To keep in contact they ma
         </ul>
         <br>
         <ul class="list-inline">
-<!--          <li>
-            <a href="https://facebook.com/"><i class="fa fa-facebook fa-fw fa-3x"></i></a>
-          </li>-->
           <li>
             <a href="https://twitter.com/apache_oodt"><i class="fa fa-twitter fa-fw fa-3x"></i></a>
           </li>
@@ -219,7 +210,7 @@ Apache OODT has a dedicated community based globally. To keep in contact they ma
           </li>
         </ul>
         <hr class="small">
-        <p class="text-muted">Copyright &copy; The Apache Foundation 2018</p>
+        <p class="text-muted">Copyright &copy; The Apache Foundation <span id="currentYear"></span></p>
       </div>
     </div>
   </div>
@@ -234,6 +225,7 @@ Apache OODT has a dedicated community based globally. To keep in contact they ma
 <!-- Custom Theme JavaScript -->
 <script src="/js/custom.js"></script>
 
+<script>document.getElementById("currentYear").innerHTML = new Date().getFullYear()</script>
 
 </body>
 

--- a/documentation.html
+++ b/documentation.html
@@ -68,6 +68,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html">Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>

--- a/download.html
+++ b/download.html
@@ -84,23 +84,41 @@
 
   <div class="row">
     <div class="col-md-8">
-      <h1>Introduction</h1>
+      <h1>Download</h1>
       <p>Thanks for checking out Apache OODT. On this page you can download our official release.<br/> <strong>N.B. OODT is ONLY released as source code and NOT binary</strong>. This is because you will most likely want to recompile various aspects of the codebase with configuration before deploying an OODT system.</p>
 
       <p>See the <a href="https://raw.githubusercontent.com/apache/oodt/1.2.3/CHANGES.txt">1.2.3-CHANGES.txt</a> file for more information on the list of updates in this release.</p>
 
       <p>OODT is always distributed under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License, version 2.0</a>.</p>
 
-      <h1>Prerequisites</h1>
+      <h2>Prerequisites</h2>
       <p>You require <a href="http://maven.apache.org/">Apache Maven</a> to build the OODT source code. Maven can either be downloaded and installed manually or alternatively via command line via your operating system package manager.</p>
 
-      <h1>Official Release</h1>
-      <p>AUG-2018: The Latest Apache™ OODT version 1.2.3 is now released and available for download.</p>
+    <h4>Operating Systems</h4>
 
-      <p><a href="http://www.apache.org/dyn/closer.lua/oodt" class="btn btn-primary">Download OODT</a>
-      <h2>Download OODT</h2>
+    <ul>
+      <li>UNIX (Linux, OS/X, Solaris, BSD, etc.)</li>
+      <li>Windows with Cygwin</li>
+    </ul>
 
-      <h3>Mirrors</h3>
+    <h4>Software</h4>
+
+    <ul>
+      <li>Java and/or Python</li>
+      <li>Maven</li>
+    </ul>
+
+    <h4>Required knowledge</h4>
+    <ul>
+      <li>XML</li>
+      <li>Java and/or Python (in order to customize and extend)</li>
+    </ul>
+
+    <h2>Official Release</h2>
+    <p>AUG-2018: The Latest Apache™ OODT version 1.2.3 is now released and available for download.</p>
+    <p><a href="http://www.apache.org/dyn/closer.lua/oodt" class="btn btn-primary">Download OODT</a>
+      
+      <h2>Mirrors</h2>
       <p>The link in the Mirrors column below should display a default mirror selection based on your inferred location. If (when you browse to it) you do not see that page, try a different browser. The checksum and signature are links to the originals on the main distribution server.</p>
 
       <table class="table">

--- a/download.html
+++ b/download.html
@@ -68,6 +68,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html">Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>

--- a/index.html
+++ b/index.html
@@ -24,13 +24,6 @@
   <link href="/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
   <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
 
-  <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-  <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-  <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-    <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-  <![endif]-->
-
 </head>
 
 
@@ -67,6 +60,9 @@
     </li>
     <li>
       <a href="/community.html" >Community</a>
+    </li>
+    <li>
+      <a href="/use-cases.html" >Use cases</a>
     </li>
       <li>
         <a href="/download.html" >Download</a>
@@ -171,12 +167,7 @@
   </div>
 
 </div>
-<div class="row col-md-12">
-  <h1>Some of our users <small>Award-winning software birthed at NASA's Jet Propulsion Laboratory</small></h1>
-  <div class="text-center" ><img src="img/nasa_logo.png"/>
-  <img src="img/darpa_logo.png"/>
-  <img src="img/nci_logo.png"/></div>
-</div>
+
 </div>
 
   <footer class="sitefooter">

--- a/medical-usecase.html
+++ b/medical-usecase.html
@@ -68,6 +68,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html" >Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>

--- a/staging-usecase.html
+++ b/staging-usecase.html
@@ -68,6 +68,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html" >Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>

--- a/streaming-usecase.html
+++ b/streaming-usecase.html
@@ -68,6 +68,9 @@
     <li>
       <a href="/community.html" >Community</a>
     </li>
+    <li>
+      <a href="/use-cases.html" >Use cases</a>
+    </li>
       <li>
         <a href="/download.html" >Download</a>
       </li>

--- a/use-cases.html
+++ b/use-cases.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Apache Object Oriented Data Technology (OODT) is the smart way to integrate and archive your processes, your data, and its metadata. It facilitates the generation, processing, management, distribution, analysis of data management, data archiving, and data analytics systems allowing for the integration of data, computation, visualization and other components.">
+    <meta name="author" content="Apache OODT">
+
+    <title>Apache OODT - Distributed Data Management</title>
+
+    <!-- Bootstrap Core CSS -->
+    <link href="/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="/css/stylish-portfolio.css" rel="stylesheet">
+
+    <!-- Custom Fonts -->
+    <link href="/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
+  </head>
+
+  <body>
+    <nav class="navbar navbar-default">
+      <div class="container-fluid">
+        <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="#"><img src="/img/oodt_asf_logo_sm.png"/></a>
+    </div>
+
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+
+    <ul class="nav navbar-nav">
+
+    <li>
+      <a href="/">Home</a>
+    </li>
+    <li>
+      <a href="/blog">News</a>
+    <li>
+      <a href="/site_docs/oodt/index.html">Components</a>
+    </li> 
+    <li>
+      <a href="/documentation.html">Documentation</a>
+    </li>
+    <li>
+      <a href="/community.html" >Community</a>
+    </li>
+    <li>
+        <a href="/use-cases.html" >Use cases</a>
+    </li>
+    <li>
+        <a href="/download.html" >Download</a>
+    </li>
+  </ul>
+  </div>
+</div>
+</nav>
+
+  
+      <div class="row col-md-8 col-md-offset-2">
+
+        <h1>Use cases</h1>
+
+        <h2>What is Apache OODT? </h2>
+  <div style="text-align: justify;">
+    <p>Having awarded in 2003 as the NASA Software of the Year, Apache Object Oriented Data Technology (OODT) began at the Jet Propulsion Laboratory, in operations cataloging pictures of Mars and helping to detect cancer. Apache OODT is smart, open source software for science, research, or otherwise.</p>
+
+    <p>Apache OODT is the superior way to integrate and archive your processes, your data, and its metadata. It spans scientific and other disciplines and enable interoperability among data agnostic systems in the varying fields. Using OODT's framework of distributed objects and databases, the data collected by scientists and engineers in disparate disciplines can be jointly searched, stored, retrieved, and analyzed. It facilitates the creation, acquisition, and growth of data management and archiving systems.</p>
+  </div>
+  
+  <h2>Why use it?</h2>
+    <p>Processing pipelines are too often one-off custom solutions that fail to scale and evolve as systems evolve. Moreover, archived data undergoes a kind of atrophy as the tools used to analyze and process it are themselves one-off solutions with no maintenance. These haphazard approaches achieve only short term success, but are not effective in data search, discovery, analysis, cataloging, processing, or archiving. OODT replaces these manual, forgettable steps with reliable workflows through distributed data grids. OODT ensures the usability and value of data even after original developers move on.</p>
+
+<h2>How?</h2>
+    <p>Haphazard processing pipelines are commonly made up of custom UNIX shell scripts and/or fragile custom written glue code of Java, Python, and Perl. OODT uses structured XML-based capturing of the processing pipeline that can be understood and modified by non-programmers to create, edit, manage and provision workflow and task execution.</p>
+
+  <h2>Our users</h2>
+
+  <div class="row col-md-12" style="margin-top: 2%;margin-bottom: 4%;">
+    <div class="text-center" >
+       <img style="margin-right: 2%" src="img/nasa_logo.png"/>
+       <img style="margin-right: 2%" src="img/darpa_logo.png"/>
+       <img src="img/nci_logo.png"/></div>
+  </div>
+
+  <p>OODT is deployed operationally in</p>
+  <ul>
+    <li>DARPA's XDATA Presidential Big Data Initiative</li>
+    <li>NASA's Airborne Snow Observatory demonstration mission.</li>
+    <li>NASA's Carbon in Arctic Reservoirs Vulnerability Experiment</li>
+    <li>National Cancer Institute's Early Detection Research Network</li>
+    <li>NASA's Orbiting Carbon Observatory</li>
+    <li>The Sinai-Helmsley Alliance for Research Excellence data coordinating center project</li>
+    <li>MIT Haystack Observatory</li>
+    <li>NASA's Megacities Carbon Project</li>
+    <li>Children's Hospital of Los Angeles's Virtual Pediatric Intensive Care Unit</li>
+    <li>The Planetary Data System</li>
+    <li>NASA's Orbiting Carbon Observatory-2</li>
+    <li>NASA's Soil Moisture Active/Passive mission</li>
+    <li>The Square Kilometre Array South Africa project</li>
+    <li>NASA's Seawinds/QuickSCAT mission</li>
+    <li>and many more...</li>
+  </ul>
+
+
+    <h2>Prerequisites</h2>
+
+    <h3>Operating Systems</h3>
+
+    <ul>
+      <li>UNIX (Linux, OS/X, Solaris, BSD, etc.)</li>
+      <li>Windows with Cygwin</li>
+    </ul>
+
+    <h3>Software</h3>
+
+    <ul>
+      <li>Java and/or Python</li>
+      <li>Maven</li>
+    </ul>
+
+    <h3>Required knowledge</h3>
+    <ul>
+      <li>XML</li>
+      <li>Java and/or Python (in order to customize and extend)</li>
+    </ul>
+    <br />
+</div>
+  
+  <footer class="sitefooter">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-10 col-lg-offset-1 text-center">
+      <a  href="http://www.apache.org/events/current-event.html">
+        <img src="http://www.apache.org/events/current-event-234x60.png"/>
+      </a>
+        <h4><strong>Apache OODT</strong>
+        </h4>
+        <p>
+          
+        </p>
+        <ul class="list-unstyled">
+          <li><i class="fa fa-envelope-o fa-fw"></i>  <a href="mailto:dev@oodt.apache.org">dev@oodt.apache.org</a>
+          </li>
+        </ul>
+        <br>
+        <ul class="list-inline">
+          <li>
+            <a href="https://twitter.com/apache_oodt"><i class="fa fa-twitter fa-fw fa-3x"></i></a>
+          </li>
+          <li>
+            <a href="https://github.com/apache/oodt"><i class="fa fa-github fa-fw fa-3x"></i></a>
+          </li>
+        </ul>
+        <hr class="small">
+        <p class="text-muted">Copyright &copy; The Apache Foundation <span id="currentYear"></span></p>
+      </div>
+    </div>
+  </div>
+</footer>
+
+  <!-- jQuery -->
+<script src="/js/jquery.js"></script>
+
+<!-- Bootstrap Core JavaScript -->
+<script src="/js/bootstrap.min.js"></script>
+
+<!-- Custom Theme JavaScript -->
+<script src="/js/custom.js"></script>
+
+<script>document.getElementById("currentYear").innerHTML = new Date().getFullYear()</script>
+</body>
+
+</html>

--- a/use-cases.html
+++ b/use-cases.html
@@ -67,17 +67,17 @@
 
         <h1>Use cases</h1>
 
-        <h2>What is Apache OODT? </h2>
+        <h2>About Apache OODT</h2>
   <div style="text-align: justify;">
     <p>Having awarded in 2003 as the NASA Software of the Year, Apache Object Oriented Data Technology (OODT) began at the Jet Propulsion Laboratory, in operations cataloging pictures of Mars and helping to detect cancer. Apache OODT is smart, open source software for science, research, or otherwise.</p>
 
     <p>Apache OODT is the superior way to integrate and archive your processes, your data, and its metadata. It spans scientific and other disciplines and enable interoperability among data agnostic systems in the varying fields. Using OODT's framework of distributed objects and databases, the data collected by scientists and engineers in disparate disciplines can be jointly searched, stored, retrieved, and analyzed. It facilitates the creation, acquisition, and growth of data management and archiving systems.</p>
   </div>
   
-  <h2>Why use it?</h2>
+  <h2>Why Apache OODT?</h2>
     <p>Processing pipelines are too often one-off custom solutions that fail to scale and evolve as systems evolve. Moreover, archived data undergoes a kind of atrophy as the tools used to analyze and process it are themselves one-off solutions with no maintenance. These haphazard approaches achieve only short term success, but are not effective in data search, discovery, analysis, cataloging, processing, or archiving. OODT replaces these manual, forgettable steps with reliable workflows through distributed data grids. OODT ensures the usability and value of data even after original developers move on.</p>
 
-<h2>How?</h2>
+<h2>How OODT does that?</h2>
     <p>Haphazard processing pipelines are commonly made up of custom UNIX shell scripts and/or fragile custom written glue code of Java, Python, and Perl. OODT uses structured XML-based capturing of the processing pipeline that can be understood and modified by non-programmers to create, edit, manage and provision workflow and task execution.</p>
 
   <h2>Our users</h2>
@@ -105,32 +105,11 @@
     <li>NASA's Soil Moisture Active/Passive mission</li>
     <li>The Square Kilometre Array South Africa project</li>
     <li>NASA's Seawinds/QuickSCAT mission</li>
-    <li>and many more...</li>
-  </ul>
+</ul>
+<p>and many more...</p>
 
-
-    <h2>Prerequisites</h2>
-
-    <h3>Operating Systems</h3>
-
-    <ul>
-      <li>UNIX (Linux, OS/X, Solaris, BSD, etc.)</li>
-      <li>Windows with Cygwin</li>
-    </ul>
-
-    <h3>Software</h3>
-
-    <ul>
-      <li>Java and/or Python</li>
-      <li>Maven</li>
-    </ul>
-
-    <h3>Required knowledge</h3>
-    <ul>
-      <li>XML</li>
-      <li>Java and/or Python (in order to customize and extend)</li>
-    </ul>
-    <br />
+<br/>
+    
 </div>
   
   <footer class="sitefooter">


### PR DESCRIPTION
Included changes:
1. Create a new page for adding use cases and company logos
2. Remove company logos from the home page
3. Redesign the community page
4. Move prerequisites mentioned in the /use-cases page to the /downloads page