### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/cli/src/test/java/org/apache/oodt/cas/cli/option/validator/TestFileExistCmdLineOptionValidator.java
+++ b/cli/src/test/java/org/apache/oodt/cas/cli/option/validator/TestFileExistCmdLineOptionValidator.java
@@ -23,8 +23,8 @@ import static org.apache.oodt.cas.cli.test.util.TestUtils.createSimpleOption;
 //JDK imports
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
-//JUnit imports
 import junit.framework.TestCase;
 
 //OODT imports
@@ -54,7 +54,7 @@ public class TestFileExistCmdLineOptionValidator extends TestCase {
             .validate(instance).getGrade());
 
       // Test pass case.
-      File tempFile = File.createTempFile("bogus", "bogus");
+      File tempFile = Files.createTempFile("bogus", "bogus").toFile();
       tempFile.deleteOnExit();
       instance = createOptionInstance(createSimpleOption("test", false),
             tempFile.getAbsolutePath());

--- a/commons/src/test/java/org/apache/oodt/commons/ConfigurationTest.java
+++ b/commons/src/test/java/org/apache/oodt/commons/ConfigurationTest.java
@@ -16,6 +16,7 @@
 package org.apache.oodt.commons;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.*;
 import junit.framework.*;
 
@@ -33,7 +34,7 @@ public class ConfigurationTest extends TestCase {
 
 	protected void setUp() throws Exception {
 		// Create a temporary test configuration file.
-		tmpFile = File.createTempFile("conf", ".xml");
+		tmpFile = Files.createTempFile("conf", ".xml").toFile();
 		BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(tmpFile));
 		byte[] doc = TEST_DOC.getBytes();
 		out.write(doc, 0, doc.length);

--- a/commons/src/test/java/org/apache/oodt/commons/object/jndi/ObjectContextTest.java
+++ b/commons/src/test/java/org/apache/oodt/commons/object/jndi/ObjectContextTest.java
@@ -17,6 +17,7 @@ package org.apache.oodt.commons.object.jndi;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -46,7 +47,7 @@ public class ObjectContextTest extends TestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
-		aliasFile = File.createTempFile("test", ".properties");
+		aliasFile = Files.createTempFile("test", ".properties").toFile();
 		aliasFile.deleteOnExit();
 		Properties aliases = new Properties();
 		aliases.setProperty("urn:alias:x", "urn:a:x");

--- a/crawler/src/test/java/org/apache/oodt/cas/crawl/typedetection/TestMimeExtractorConfigReader.java
+++ b/crawler/src/test/java/org/apache/oodt/cas/crawl/typedetection/TestMimeExtractorConfigReader.java
@@ -18,6 +18,7 @@ package org.apache.oodt.cas.crawl.typedetection;
 
 //JDK imports
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.UUID;
 
@@ -47,7 +48,7 @@ public class TestMimeExtractorConfigReader extends TestCase {
 
    @Override
    public void setUp() throws Exception {
-      File tmpFile = File.createTempFile("bogus", "bogus");
+      File tmpFile = Files.createTempFile("bogus", "bogus").toFile();
       tmpDir = new File(tmpFile.getParentFile(), UUID.randomUUID().toString());
       tmpFile.delete();
       if (!tmpDir.mkdirs()) {

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestDataSourceCatalog.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestDataSourceCatalog.java
@@ -35,6 +35,7 @@ import org.apache.oodt.commons.database.SqlScript;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -99,7 +100,7 @@ public class TestDataSourceCatalog extends TestCase {
             File tempFile;
 
             try {
-                tempFile = File.createTempFile("foo", "bar");
+                tempFile = Files.createTempFile("foo", "bar").toFile();
                 tempFile.deleteOnExit();
                 tempDir = tempFile.getParentFile();
             } catch (Exception e) {

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestLuceneCatalog.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/catalog/TestLuceneCatalog.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
@@ -93,7 +94,7 @@ public class TestLuceneCatalog extends TestCase {
         File tempFile;
 
         try {
-            tempFile = File.createTempFile("foo", "bar");
+            tempFile = Files.createTempFile("foo", "bar").toFile();
             tempFile.deleteOnExit();
             tempDir = tempFile.getParentFile();
         } catch (Exception e) {

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/TestFileManagerCli.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/TestFileManagerCli.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Properties;
 //JUnit imports
 import junit.framework.TestCase;
@@ -323,7 +324,7 @@ public class TestFileManagerCli extends TestCase {
 
    public void testDumpMetadata() throws IOException {
       String productId = "TestProductId";
-      File bogusFile = File.createTempFile("bogus", "bogus");
+      File bogusFile = Files.createTempFile("bogus", "bogus").toFile();
       File tmpFile = new File(bogusFile.getParentFile(), "CliDumpMetadata");
       tmpFile.mkdirs();
       bogusFile.delete();

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestDumpMetadataCliAction.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestDumpMetadataCliAction.java
@@ -24,8 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 
-//Apache imports
 import org.apache.commons.io.FileUtils;
 
 //OODT imports
@@ -53,7 +53,7 @@ public class TestDumpMetadataCliAction extends TestCase {
 
    @Override
    public void setUp() throws Exception {
-      File bogusFile = File.createTempFile("bogus", "bogus");
+      File bogusFile = Files.createTempFile("bogus", "bogus").toFile();
       tmpFile = new File(bogusFile.getParentFile(), "MetadataDump");
       tmpFile.mkdirs();
       bogusFile.delete();

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestIngestProductCliAction.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/cli/action/TestIngestProductCliAction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Comparator;
 
@@ -237,7 +238,7 @@ public class TestIngestProductCliAction extends TestCase {
    }
 
    private File createTmpDir() throws IOException {
-      File bogusDir = File.createTempFile("bogus", "bogus");
+      File bogusDir = Files.createTempFile("bogus", "bogus").toFile();
       File tmpDir = bogusDir.getParentFile();
       bogusDir.delete();
       tmpDir = new File(tmpDir, "Metadata");

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/datatransfer/TestInPlaceDataTransferer.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/datatransfer/TestInPlaceDataTransferer.java
@@ -24,8 +24,8 @@ import org.apache.oodt.cas.filemgr.structs.Reference;
 
 //JDK imports
 import java.io.File;
+import java.nio.file.Files;
 
-//Junit imports
 import junit.framework.TestCase;
 
 /**
@@ -48,7 +48,7 @@ public class TestInPlaceDataTransferer extends TestCase {
         transfer = (InPlaceDataTransferer) new InPlaceDataTransferFactory()
                 .createDataTransfer();
         try {
-            File tempFileSrc = File.createTempFile("foo", ".txt");
+            File tempFileSrc = Files.createTempFile("foo", ".txt").toFile();
             tempFileSrc.deleteOnExit();
             productOrigLoc = tempFileSrc.getAbsolutePath();
             productExpectedLoc = tempFileSrc.getParent();

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/datatransfer/TestLocalDataTransferer.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/datatransfer/TestLocalDataTransferer.java
@@ -28,6 +28,7 @@ import org.apache.oodt.cas.filemgr.structs.exceptions.DataTransferException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.UUID;
 
 //Junit imports
@@ -55,7 +56,7 @@ public class TestLocalDataTransferer extends TestCase {
          .createDataTransfer();
       URL url = this.getClass().getResource("/test.txt");
       origFile = new File(url.getFile());
-      File testFile = File.createTempFile("test", ".txt");
+      File testFile = Files.createTempFile("test", ".txt").toFile();
       testDir = new File(testFile.getParentFile(), UUID.randomUUID().toString());
       repoDir = new File(testDir, "repo");
       if (!repoDir.mkdirs()) {

--- a/filemgr/src/test/java/org/apache/oodt/cas/filemgr/structs/type/TestTypeHandler.java
+++ b/filemgr/src/test/java/org/apache/oodt/cas/filemgr/structs/type/TestTypeHandler.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -99,7 +100,7 @@ public class TestTypeHandler extends TestCase {
         File tempFile;
 
         try {
-            tempFile = File.createTempFile("foo", "bar");
+            tempFile = Files.createTempFile("foo", "bar").toFile();
             tempFile.deleteOnExit();
             tempDir = tempFile.getParentFile();
         } catch (Exception e) {

--- a/metadata/src/test/java/org/apache/oodt/cas/metadata/filenaming/TestPathUtilsNamingConvention.java
+++ b/metadata/src/test/java/org/apache/oodt/cas/metadata/filenaming/TestPathUtilsNamingConvention.java
@@ -19,6 +19,7 @@ package org.apache.oodt.cas.metadata.filenaming;
 //JDK imports
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.UUID;
 
 //Apache imports
@@ -39,7 +40,7 @@ import junit.framework.TestCase;
 public class TestPathUtilsNamingConvention extends TestCase {
 
    public void testRename() throws IOException, NamingConventionException {
-      File tmpFile = File.createTempFile("bogus", "bogus");
+      File tmpFile = Files.createTempFile("bogus", "bogus").toFile();
       File tmpDir = new File(tmpFile.getParentFile(),
             UUID.randomUUID().toString());
       if (!tmpDir.mkdirs()) {

--- a/pge/src/test/java/org/apache/oodt/cas/pge/TestPGETaskInstance.java
+++ b/pge/src/test/java/org/apache/oodt/cas/pge/TestPGETaskInstance.java
@@ -55,6 +55,7 @@ import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+
 //JDK imports
 //JUnit imports
 //Apache imports
@@ -647,7 +649,7 @@ public class TestPGETaskInstance {
    }
 
    private File createTmpDir() throws Exception {
-      File tmpFile = File.createTempFile("bogus", "bogus");
+      File tmpFile = Files.createTempFile("bogus", "bogus").toFile();
       File tmpDir = new File(tmpFile.getParentFile(), UUID.randomUUID().toString());
       tmpFile.delete();
       tmpDir.mkdirs();

--- a/pge/src/test/java/org/apache/oodt/cas/pge/writers/VelocityConfigFileWriterTest.java
+++ b/pge/src/test/java/org/apache/oodt/cas/pge/writers/VelocityConfigFileWriterTest.java
@@ -23,6 +23,7 @@ import org.apache.oodt.cas.metadata.Metadata;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,7 +41,7 @@ public class VelocityConfigFileWriterTest extends TestCase {
     metadata.addMetadata("name", "Chris");
     metadata.addMetadata("name", "Paul");
     metadata.addMetadata("conference", "ApacheCon");
-    File config = File.createTempFile("config", ".out");
+    File config = Files.createTempFile("config", ".out").toFile();
     try {
       vcfw.generateFile(config.toString(), metadata, LOG, url.getFile());
     } catch (Exception e) {

--- a/webapp/wmservices/src/main/java/org/apache/oodt/cas/wmservices/repository/PackagedWorkflowManager.java
+++ b/webapp/wmservices/src/main/java/org/apache/oodt/cas/wmservices/repository/PackagedWorkflowManager.java
@@ -19,6 +19,7 @@ package org.apache.oodt.cas.wmservices.repository;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +84,7 @@ public class PackagedWorkflowManager {
     try {
       this.loadTasksToRepo(workflow);
       String workflowId = this.repo.addWorkflow(workflow);
-      File f = File.createTempFile("tempworkflow-", "-packaged");
+      File f = Files.createTempFile("tempworkflow-", "-packaged").toFile();
       this.saveWorkflow(workflowId, f.getAbsolutePath());
       String workflowXML = FileUtils.readFileToString(f);
       f.delete();
@@ -107,7 +108,7 @@ public class PackagedWorkflowManager {
   public Workflow parsePackagedWorkflow(String workflowID, String workflowXML)
       throws RepositoryException {
     try {
-      File tmpfile = File.createTempFile("tempworkflow-", "-packaged");
+      File tmpfile = Files.createTempFile("tempworkflow-", "-packaged").toFile();
       FileUtils.writeStringToFile(tmpfile, workflowXML);
       PackagedWorkflowRepository tmprepo = new PackagedWorkflowRepository(
           Collections.singletonList(tmpfile));

--- a/workflow/src/test/java/org/apache/oodt/cas/workflow/instrepo/TestLuceneWorkflowInstanceRepository.java
+++ b/workflow/src/test/java/org/apache/oodt/cas/workflow/instrepo/TestLuceneWorkflowInstanceRepository.java
@@ -31,6 +31,7 @@ import org.apache.oodt.cas.workflow.structs.exceptions.InstanceRepositoryExcepti
 //JDK imports
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Vector;
 
@@ -114,7 +115,7 @@ public class TestLuceneWorkflowInstanceRepository extends TestCase implements
         File tempFile;
 
         try {
-            tempFile = File.createTempFile("foo", "bar");
+            tempFile = Files.createTempFile("foo", "bar").toFile();
             tempFile.deleteOnExit();
             tempDir = tempFile.getParentFile();
         } catch (Exception e) {

--- a/workflow/src/test/java/org/apache/oodt/cas/workflow/repository/TestWorkflowDataSourceRepository.java
+++ b/workflow/src/test/java/org/apache/oodt/cas/workflow/repository/TestWorkflowDataSourceRepository.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,7 +83,7 @@ public class TestWorkflowDataSourceRepository {
         File tempFile;
 
         try {
-            tempFile = File.createTempFile("foo", "bar");
+            tempFile = Files.createTempFile("foo", "bar").toFile();
             tempFile.deleteOnExit();
             tempDir = tempFile.getParentFile();
         } catch (Exception e) {


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
